### PR TITLE
Convert from AngleAxis straight to RotMatrix using Rodrigues' rotation formula

### DIFF
--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -135,6 +135,7 @@ end
 @inline Base.getindex(aa::RodriguesVec, i::Integer) = Quat(aa)[i]
 
 # define its interaction with other angle representations
+@inline Base.convert{R <: RotMatrix}(::Type{R}, rv::RodriguesVec) = convert(R, AngleAxis(rv))
 
 function Base.convert{AA <: AngleAxis}(::Type{AA}, rv::RodriguesVec)
     # TODO: consider how to deal with derivative near theta = 0. There should be a first-order expansion here.

--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -33,6 +33,32 @@ end
 @inline (::Type{AA}){AA <: AngleAxis}(t::NTuple{9}) = AA(Quat(t))
 @inline Base.getindex(aa::AngleAxis, i::Integer) = Quat(aa)[i]
 
+@inline function Base.convert{R <: RotMatrix}(::Type{R}, aa::AngleAxis)
+    # Rodrigues' rotation formula.
+    T = eltype(aa)
+
+    s = sin(aa.theta)
+    c = cos(aa.theta)
+    c1 = one(T) - c
+
+    c1x2 = c1 * aa.axis_x^2
+    c1y2 = c1 * aa.axis_y^2
+    c1z2 = c1 * aa.axis_z^2
+
+    c1xy = c1 * aa.axis_x * aa.axis_y
+    c1xz = c1 * aa.axis_x * aa.axis_z
+    c1yz = c1 * aa.axis_y * aa.axis_z
+
+    sx = s * aa.axis_x
+    sy = s * aa.axis_y
+    sz = s * aa.axis_z
+
+    # Note that the RotMatrix constructor argument order makes this look transposed:
+    R(one(T) - c1y2 - c1z2, c1xy + sz, c1xz - sy,
+      c1xy - sz, one(T) - c1x2 - c1z2, c1yz + sx,
+      c1xz + sy, c1yz - sx, one(T) - c1x2 - c1y2)
+end
+
 @inline function Base.convert{Q <: Quat}(::Type{Q}, aa::AngleAxis)
     qtheta = cos(aa.theta / 2)
     s = sin(aa.theta / 2) / sqrt(aa.axis_x * aa.axis_x + aa.axis_y * aa.axis_y + aa.axis_z * aa.axis_z)


### PR DESCRIPTION
Also make conversion from `RodriguesVec` to `RotMatrix` go through `AngleAxis` instead of `Quat`.

This is significantly faster.

### `AngleAxis` --> `RotMatrix`
```julia
@benchmark RotMatrix(aa) setup = aa = rand(AngleAxis)
```

Before:
```
BenchmarkTools.Trial: 
  memory estimate:  0.00 bytes
  allocs estimate:  0
  --------------
  minimum time:     42.916 ns (0.00% GC)
  median time:      57.375 ns (0.00% GC)
  mean time:        56.766 ns (0.00% GC)
  maximum time:     115.718 ns (0.00% GC)
```

After:
```
BenchmarkTools.Trial: 
  memory estimate:  0.00 bytes
  allocs estimate:  0
  --------------
  minimum time:     22.549 ns (0.00% GC)
  median time:      32.279 ns (0.00% GC)
  mean time:        32.430 ns (0.00% GC)
  maximum time:     85.305 ns (0.00% GC)
```


### `RodriguesVec` --> `RotMatrix`
```julia
@benchmark RotMatrix(vec) setup = vec = rand(RodriguesVec)
```

Before:
```
BenchmarkTools.Trial: 
  memory estimate:  0.00 bytes
  allocs estimate:  0
  --------------
  minimum time:     55.586 ns (0.00% GC)
  median time:      72.386 ns (0.00% GC)
  mean time:        71.351 ns (0.00% GC)
  maximum time:     107.514 ns (0.00% GC)
```

After:
```
BenchmarkTools.Trial: 
  memory estimate:  0.00 bytes
  allocs estimate:  0
  --------------
  minimum time:     36.108 ns (0.00% GC)
  median time:      47.739 ns (0.00% GC)
  mean time:        47.565 ns (0.00% GC)
  maximum time:     93.466 ns (0.00% GC)
```
