### PR TITLE
Add function to compute Quaternion given two SVector{3}s

### DIFF
--- a/src/Rotations.jl
+++ b/src/Rotations.jl
@@ -7,6 +7,7 @@ using StaticArrays
 
 import Base: convert, eltype, size, length, getindex, inv, *, Tuple, eye
 
+include("util.jl")
 include("core_types.jl")
 include("quaternion_types.jl")
 include("angleaxis_types.jl")

--- a/src/Rotations.jl
+++ b/src/Rotations.jl
@@ -30,7 +30,10 @@ export
 
     # angle and axis introspection
     rotation_angle,
-    rotation_axis
+    rotation_axis,
+
+    # quaternion from two vectors
+    rotation_between
 
     # derivatives (names clash with ForwarDiff?)
     #jacobian, hessian

--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -29,38 +29,6 @@ end
 # but this isn't quite what we mean when we have 4 inputs (not 9).
 @inline (::Type{AngleAxis}){Θ,X,Y,Z}(θ::Θ, x::X, y::Y, z::Z) = AngleAxis{promote_type(promote_type(promote_type(Θ, X), Y), Z)}(θ, x, y, z)
 
-"""
-    AngleAxis(from, to)
-
-Compute the AngleAxis rotation with smallest angle that rotates vector `from`
-to vector `to` (up to scaling).
-"""
-AngleAxis(from::AbstractVector, to::AbstractVector) = AngleAxis(SVector{3}(from), SVector{3}(to))
-function AngleAxis(from::SVector{3}, to::SVector{3})
-    normfrom = norm(from)
-    normto = norm(to)
-    normprod = normfrom * normto
-    T = typeof(normprod)
-    normprod < eps(T) && throw(ArgumentError("Input vectors must be nonzero."))
-    cosϕ = clamp(dot(from, to) / normprod, -one(T), one(T))
-    ϕ = acos(cosϕ)
-
-    return if ϕ < eps(T)
-         # 'from' and 'to' are aligned
-        eye(AngleAxis{Float64})
-    else
-        axis = cross(from, to)
-        if dot(axis, axis) < 10 * eps(T)^2
-            # 'from' and 'to' point in opposite directions.
-            # find axis that is perpendicular to 'from' and 'to'
-            maxnormvec = normfrom > normto ? from : to
-            axis = perpendicular_vector(maxnormvec)
-        end
-        # note: relies on normalization of axis in AngleAxis constructor:
-        AngleAxis(ϕ, axis[1], axis[2], axis[3])
-    end
-end
-
 # These 2 functions are enough to satisfy the entire StaticArrays interface:
 @inline (::Type{AA}){AA <: AngleAxis}(t::NTuple{9}) = AA(Quat(t))
 @inline Base.getindex(aa::AngleAxis, i::Integer) = Quat(aa)[i]

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,0 +1,21 @@
+"""
+    perpendicular_vector(vec)
+
+Compute a vector perpendicular to `vec` by switching the two elements with
+largest absolute value, flipping the sign of the second largest, and setting the
+remaining element to zero.
+"""
+function perpendicular_vector(vec::SVector{3})
+    T = eltype(vec)
+
+    # find indices of the two elements of vec with the largest absolute values:
+    absvec = abs(vec)
+    ind1 = indmax(absvec) # index of largest element
+    absvec2 = @SVector [ifelse(i == ind1, typemin(T), absvec[i]) for i = 1 : 3] # set largest element to typemin(T)
+    ind2 = indmax(absvec2) # index of second-largest element
+
+    # perp[ind1] = -vec[ind2], perp[ind2] = vec[ind1], set remaining element to zero:
+    perpind1 = -vec[ind2]
+    perpind2 = vec[ind1]
+    perp = @SVector [ifelse(i == ind1, perpind1, ifelse(i == ind2, perpind2, zero(T))) for i = 1 : 3]
+end

--- a/src/util.jl
+++ b/src/util.jl
@@ -11,11 +11,11 @@ function perpendicular_vector(vec::SVector{3})
     # find indices of the two elements of vec with the largest absolute values:
     absvec = abs(vec)
     ind1 = indmax(absvec) # index of largest element
-    absvec2 = @SVector [ifelse(i == ind1, typemin(T), absvec[i]) for i = 1 : 3] # set largest element to typemin(T)
+    @inbounds absvec2 = @SVector [ifelse(i == ind1, typemin(T), absvec[i]) for i = 1 : 3] # set largest element to typemin(T)
     ind2 = indmax(absvec2) # index of second-largest element
 
     # perp[ind1] = -vec[ind2], perp[ind2] = vec[ind1], set remaining element to zero:
-    perpind1 = -vec[ind2]
-    perpind2 = vec[ind1]
+    @inbounds perpind1 = -vec[ind2]
+    @inbounds perpind2 = vec[ind1]
     perp = @SVector [ifelse(i == ind1, perpind1, ifelse(i == ind2, perpind2, zero(T))) for i = 1 : 3]
 end

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -204,36 +204,37 @@ all_types = (RotMatrix{3}, Quat, SPQuat, AngleAxis, RodriguesVec,
     end
 
     #########################################################################
-    # Check construction of AngleAxis given two vectors
+    # Check construction of Quat given two vectors
     #########################################################################
 
-    @testset "Testing angle / axis given two vectors" begin
+    @testset "Testing construction of Quat given two vectors" begin
         angle_axis_test(from, to, rot, atol) = isapprox(rot * from * norm(to) / norm(from), to; atol = atol)
 
         for i = 1 : 10000
-            from = rand(SVector{3, Float64})
+            from = randn(SVector{3, Float64})
             to = rand(SVector{3, Float64})
-            rot = AngleAxis(from, to)
+            rot = rotation_between(from, to)
             @test angle_axis_test(from, to, rot, 1e-10)
         end
 
         # degenerate cases
         for i = 1 : 10000
-            from = rand(SVector{3, Float64})
+            from = randn(SVector{3, Float64})
             to = randn() * from # either from and to are aligned, or in opposite directions
-            rot = AngleAxis(from, to)
+            rot = rotation_between(from, to)
+            # @show rot
             @test angle_axis_test(from, to, rot, 1e-7)
         end
         for direction = 1 : 3
             for i = 1 : 10000
                 from = @SVector [ifelse(i == direction, 1., 0.) for i = 1 : 3] # unit vector in direction 'direction'
                 to = randn() * from
-                rot = AngleAxis(from, to)
+                rot = rotation_between(from, to)
                 @test angle_axis_test(from, to, rot, 1e-7)
             end
         end
-        @test_throws ArgumentError AngleAxis(zero(SVector{3}), rand(SVector{3}))
-        @test_throws ArgumentError AngleAxis(rand(SVector{3}), zero(SVector{3}))
+        @test_throws ArgumentError rotation_between(zero(SVector{3}), rand(SVector{3}))
+        @test_throws ArgumentError rotation_between(rand(SVector{3}), zero(SVector{3}))
     end
 
     #########################################################################

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -203,6 +203,38 @@ all_types = (RotMatrix{3}, Quat, SPQuat, AngleAxis, RodriguesVec,
         # TODO RotX, RotXY?
     end
 
+    #########################################################################
+    # Check construction of AngleAxis given two vectors
+    #########################################################################
+
+    @testset "Testing angle / axis given two vectors" begin
+        angle_axis_test(from, to, rot, atol) = isapprox(rot * from * norm(to) / norm(from), to; atol = atol)
+
+        for i = 1 : 10000
+            from = rand(SVector{3, Float64})
+            to = rand(SVector{3, Float64})
+            rot = AngleAxis(from, to)
+            @test angle_axis_test(from, to, rot, 1e-10)
+        end
+
+        # degenerate cases
+        for i = 1 : 10000
+            from = rand(SVector{3, Float64})
+            to = randn() * from # either from and to are aligned, or in opposite directions
+            rot = AngleAxis(from, to)
+            @test angle_axis_test(from, to, rot, 1e-7)
+        end
+        for direction = 1 : 3
+            for i = 1 : 10000
+                from = @SVector [ifelse(i == direction, 1., 0.) for i = 1 : 3] # unit vector in direction 'direction'
+                to = randn() * from
+                rot = AngleAxis(from, to)
+                @test angle_axis_test(from, to, rot, 1e-7)
+            end
+        end
+        @test_throws ArgumentError AngleAxis(zero(SVector{3}), rand(SVector{3}))
+        @test_throws ArgumentError AngleAxis(rand(SVector{3}), zero(SVector{3}))
+    end
 
     #########################################################################
     # Check roll, pitch, yaw constructors

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ samb = detect_ambiguities(StaticArrays, Base, Core)
 
 # TODO test mean()
 
+include("util_tests.jl")
 include("2d.jl")
 include("rotation_tests.jl")
 include("derivative_tests.jl")

--- a/test/util_tests.jl
+++ b/test/util_tests.jl
@@ -1,0 +1,10 @@
+@testset "Util" begin
+    @testset "Perpendicular vector" begin
+        for i = 1 : 100
+            vec = rand(SVector{3, Float64})
+            perp = Rotations.perpendicular_vector(vec)
+            @test norm(perp) >= maximum(abs(vec))
+            @test isapprox(dot(vec, perp), 0.; atol = 1e-10)
+        end
+    end
+end


### PR DESCRIPTION
Adds a constructor for `AngleAxis` given two vectors, `from` and `to`, such that applying the constructed rotation to `from` results in `to` (up to scaling). I needed this and thought it might be useful for others as well.