### PR TITLE
Remove 0.5 prerelease from allowed julia versions

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.5-
+julia 0.5
 StaticArrays 0.0.3


### PR DESCRIPTION
A trivial change.  may as well stick it through CI