### PR TITLE
Adapt to Size trait changes introduced in StaticArrays 0.3.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.5
-StaticArrays 0.0.3
+StaticArrays 0.3.0

--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -6,10 +6,9 @@ unitary (orthogonal) `N`×`N` matrices.
 """
 abstract Rotation{N,T} <: StaticMatrix{T}
 
-Base.@pure Base.size{N}(::Type{Rotation{N}}) = (N,N)
-Base.@pure Base.size{N,T}(::Type{Rotation{N,T}}) = (N,N)
-Base.@pure Base.size{R<:Rotation}(::Type{R}) = size(supertype(R))
-size(r::Rotation) = size(typeof(r))
+Base.@pure StaticArrays.Size{N}(::Type{Rotation{N}}) = Size(N,N)
+Base.@pure StaticArrays.Size{N,T}(::Type{Rotation{N,T}}) = Size(N,N)
+Base.@pure StaticArrays.Size{R<:Rotation}(::Type{R}) = Size(supertype(R))
 Base.ctranspose(r::Rotation) = inv(r)
 Base.transpose{N,T<:Real}(r::Rotation{N,T}) = inv(r)
 


### PR DESCRIPTION
Adapts to https://github.com/JuliaArrays/StaticArrays.jl/pull/105. Rotations.jl tests currently fail with StaticArrays 0.3.0.