### PR TITLE
Update to StaticArrays 0.5

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.6-
-StaticArrays 0.4.0 0.5-
+StaticArrays 0.5

--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -1,10 +1,10 @@
 """
-    abstract type Rotation{N,T} <: StaticMatrix{T}
+    abstract type Rotation{N,T} <: StaticMatrix{N,N,T}
 
 An abstract type representing `N`-dimensional rotations. More abstractly, they represent
 unitary (orthogonal) `N`×`N` matrices.
 """
-abstract type Rotation{N,T} <: StaticMatrix{T} end
+abstract type Rotation{N,T} <: StaticMatrix{N,N,T} end
 
 Base.@pure StaticArrays.Size{N}(::Type{Rotation{N}}) = Size(N,N)
 Base.@pure StaticArrays.Size{N,T}(::Type{Rotation{N,T}}) = Size(N,N)


### PR DESCRIPTION
Unfortunately, there are some problems.

First, a `detect_ambiguities` call results in:
```
ERROR: LoadError: TypeError: apply_type: in Vararg count, expected Int64, got Type{Any}
Stacktrace:
 [1] #isambiguous#23(::Bool, ::Function, ::Method, ::Method) at ./reflection.jl:972
 [2] (::Base.#kw##isambiguous)(::Array{Any,1}, ::Base.#isambiguous, ::Method, ::Method) at ./<missing>:0
 [3] #detect_ambiguities#20(::Bool, ::Bool, ::Void, ::Function, ::Module, ::Vararg{Module,N} where N) at ./test.jl:1158
 [4] detect_ambiguities(::Module, ::Vararg{Module,N} where N) at ./test.jl:1133
 [5] include_from_node1(::String) at ./loading.jl:539
 [6] include(::String) at ./sysimg.jl:14
 [7] process_options(::Base.JLOptions) at ./client.jl:305
 [8] _start() at ./client.jl:371
while loading /Users/twan/code/julia/RigidBodyDynamics/v0.6/Rotations/test/runtests.jl, in expression starting on line 6
```

Second, if I comment out the ambiguity tests, most tests pass, but I run into type inference problems that appear to point to the same root cause as the ambiguity test problems:
```
WARNING: An error occurred during inference. Type inference is now partially disabled.
TypeError(func=:apply_type, context="Vararg count", expected=Int64, got=Any)
rec_backtrace at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/stackwalk.c:84
record_backtrace at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/task.c:245 [inlined]
jl_throw at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/task.c:564
jl_type_error_rt at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/rtutils.c:118
inst_datatype at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/jltypes.c:1045
inst_type_w_ at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/jltypes.c:1400
inst_tuple_w_ at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/jltypes.c:1290
inst_type_w_ at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/jltypes.c:1385
inst_all at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/jltypes.c:1240 [inlined]
inst_datatype at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/jltypes.c:1172
inst_type_w_ at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/jltypes.c:1400
inst_type_w_ at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/jltypes.c:1345
jl_substitute_var at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/jltypes.c:850
finish_unionall at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/subtype.c:1406
intersect_unionall_ at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/subtype.c:1539
intersect_unionall at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/subtype.c:1565
intersect at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/subtype.c:1910
intersect_tuple at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/subtype.c:1653 [inlined]
intersect at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/subtype.c:1961
intersect_unionall_ at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/subtype.c:1506
intersect_unionall at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/subtype.c:1551
intersect at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/subtype.c:1910
intersect_all at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/subtype.c:2031
jl_type_intersection_env_s at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/subtype.c:2135
jl_typemap_intersection_node_visitor at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/typemap.c:481
jl_typemap_intersection_visitor at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/typemap.c:545
ml_matches at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/gf.c:2384
jl_matching_methods at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/gf.c:1618
_methods_by_ftype at ./reflection.jl:521
jlcall__methods_by_ftype_688 at /Applications/Julia-0.6.app/Contents/Resources/julia/lib/julia/sys.dylib (unknown line)
abstract_call_gf_by_type at ./inference.jl:1267
jlcall_abstract_call_gf_by_type_695 at /Applications/Julia-0.6.app/Contents/Resources/julia/lib/julia/sys.dylib (unknown line)
abstract_eval_call at ./inference.jl:1889
abstract_eval at ./inference.jl:1917
jlcall_abstract_eval_556 at /Applications/Julia-0.6.app/Contents/Resources/julia/lib/julia/sys.dylib (unknown line)
typeinf_frame at ./inference.jl:2760
typeinf_loop at ./inference.jl:2606
typeinf_frame at ./inference.jl:2476
typeinf_edge at ./inference.jl:2499
jlcall_typeinf_edge_749 at /Applications/Julia-0.6.app/Contents/Resources/julia/lib/julia/sys.dylib (unknown line)
abstract_call_gf_by_type at ./inference.jl:1386
jlcall_abstract_call_gf_by_type_695 at /Applications/Julia-0.6.app/Contents/Resources/julia/lib/julia/sys.dylib (unknown line)
abstract_call at ./inference.jl:1864
jlcall_abstract_call_601 at /Applications/Julia-0.6.app/Contents/Resources/julia/lib/julia/sys.dylib (unknown line)
abstract_eval_call at ./inference.jl:1894
abstract_eval at ./inference.jl:1917
jlcall_abstract_eval_556 at /Applications/Julia-0.6.app/Contents/Resources/julia/lib/julia/sys.dylib (unknown line)
typeinf_frame at ./inference.jl:2760
typeinf_loop at ./inference.jl:2606
typeinf_frame at ./inference.jl:2476
typeinf_edge at ./inference.jl:2499
jlcall_typeinf_edge_749 at /Applications/Julia-0.6.app/Contents/Resources/julia/lib/julia/sys.dylib (unknown line)
abstract_call_gf_by_type at ./inference.jl:1386
jlcall_abstract_call_gf_by_type_695 at /Applications/Julia-0.6.app/Contents/Resources/julia/lib/julia/sys.dylib (unknown line)
abstract_call at ./inference.jl:1864
jlcall_abstract_call_601 at /Applications/Julia-0.6.app/Contents/Resources/julia/lib/julia/sys.dylib (unknown line)
abstract_eval_call at ./inference.jl:1894
abstract_eval at ./inference.jl:1917
jlcall_abstract_eval_556 at /Applications/Julia-0.6.app/Contents/Resources/julia/lib/julia/sys.dylib (unknown line)
typeinf_frame at ./inference.jl:2760
typeinf_loop at ./inference.jl:2606
typeinf_frame at ./inference.jl:2476
typeinf_edge at ./inference.jl:2499
jlcall_typeinf_edge_749 at /Applications/Julia-0.6.app/Contents/Resources/julia/lib/julia/sys.dylib (unknown line)
abstract_call_gf_by_type at ./inference.jl:1386
jlcall_abstract_call_gf_by_type_695 at /Applications/Julia-0.6.app/Contents/Resources/julia/lib/julia/sys.dylib (unknown line)
abstract_call at ./inference.jl:1864
jlcall_abstract_call_601 at /Applications/Julia-0.6.app/Contents/Resources/julia/lib/julia/sys.dylib (unknown line)
abstract_eval_call at ./inference.jl:1894
abstract_eval at ./inference.jl:1917
jlcall_abstract_eval_556 at /Applications/Julia-0.6.app/Contents/Resources/julia/lib/julia/sys.dylib (unknown line)
abstract_interpret at ./inference.jl:2043
jlcall_abstract_interpret_555 at /Applications/Julia-0.6.app/Contents/Resources/julia/lib/julia/sys.dylib (unknown line)
typeinf_frame at ./inference.jl:2707
typeinf_loop at ./inference.jl:2623
typeinf_ext at ./inference.jl:2592
jlcall_typeinf_ext_0 at /Applications/Julia-0.6.app/Contents/Resources/julia/lib/julia/sys.dylib (unknown line)
jl_apply at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/./julia.h:1422 [inlined]
jl_apply_with_saved_exception_state at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/rtutils.c:257
jl_type_infer at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/gf.c:269
jl_toplevel_eval_flex at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/toplevel.c:585
jl_parse_eval_all at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/ast.c:873
jl_load at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/toplevel.c:614 [inlined]
jl_load_ at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/toplevel.c:621
include_from_node1 at ./loading.jl:539
unknown function (ip: 0x125b715c2)
include at ./sysimg.jl:14
jlcall_include_1042 at /Applications/Julia-0.6.app/Contents/Resources/julia/lib/julia/sys.dylib (unknown line)
do_call at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/interpreter.c:75
eval at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/interpreter.c:242
jl_interpret_toplevel_expr at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/interpreter.c:34
jl_toplevel_eval_flex at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/toplevel.c:575
jl_parse_eval_all at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/ast.c:873
jl_load at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/toplevel.c:614 [inlined]
jl_load_ at /Users/osx/buildbot/slave/package_osx10_9-x64/build/src/toplevel.c:621
include_from_node1 at ./loading.jl:539
jlcall_include_from_node1_18782 at /Applications/Julia-0.6.app/Contents/Resources/julia/lib/julia/sys.dylib (unknown line)
include at ./sysimg.jl:14
jlcall_include_1042 at /Applications/Julia-0.6.app/Contents/Resources/julia/lib/julia/sys.dylib (unknown line)
process_options at ./client.jl:305
_start at ./client.jl:371
jlcall__start_18957 at /Applications/Julia-0.6.app/Contents/Resources/julia/lib/julia/sys.dylib (unknown line)
true_main at /Applications/Julia-0.6.app/Contents/Resources/julia/bin/julia (unknown line)
main at /Applications/Julia-0.6.app/Contents/Resources/julia/bin/julia (unknown line)
ERROR: LoadError: LoadError: MethodError: no method matching string(::Expr)
The applicable method may be too new: running in world age 2747, while current world is 21760.
Closest candidates are:
  string(::Any...) at strings/io.jl:120 (method too new to be called from this world context.)
  string(::BigInt) at gmp.jl:522 (method too new to be called from this world context.)
  string(::BigFloat) at mpfr.jl:876 (method too new to be called from this world context.)
  ...
Stacktrace:
 [1] typeinf_ext(::Core.MethodInstance, ::UInt64) at ./inference.jl:2594
 [2] include_from_node1(::String) at ./loading.jl:539
 [3] include(::String) at ./sysimg.jl:14
 [4] include_from_node1(::String) at ./loading.jl:539
 [5] include(::String) at ./sysimg.jl:14
 [6] process_options(::Base.JLOptions) at ./client.jl:305
 [7] _start() at ./client.jl:371
while loading /Users/twan/code/julia/RigidBodyDynamics/v0.6/Rotations/test/derivative_tests.jl, in expression starting on line 5
while loading /Users/twan/code/julia/RigidBodyDynamics/v0.6/Rotations/test/runtests.jl, in expression starting on line 15
```

This is with the latest nightly, i.e.
```
Julia Version 0.6.0-pre.beta.367
Commit b838f2eec6 (2017-04-27 14:08 UTC)
Platform Info:
  OS: macOS (x86_64-apple-darwin13.4.0)
  CPU: Intel(R) Core(TM) i7-3820QM CPU @ 2.70GHz
  WORD_SIZE: 64
  BLAS: libopenblas (USE64BITINT DYNAMIC_ARCH NO_AFFINITY Sandybridge)
  LAPACK: libopenblas64_
  LIBM: libopenlibm
  LLVM: libLLVM-3.9.1 (ORCJIT, ivybridge)
```

Did you guys run into these problems as well / do you know if there is an open Julia issue that covers this?