### PR TITLE
use 0.6.0-pre as minimum julia version in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.6-
+julia 0.6.0-pre
 StaticArrays 0.5


### PR DESCRIPTION
`struct` syntax wouldn't work with early 0.6.0-dev versions,
so better to stick with the julia-0.5-compatible version of the package there