### PR TITLE
Add option to skip renormalization of `AngleAxis` and `Quat`

### DIFF
--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -14,7 +14,7 @@ might not be suitable for autodifferentation and optimization purposes).
 Note: by default, the constructor will renormalize the input so that the axis
 has length 1 (x² + y² + z² = 1).
 
-Renormalization can be skipped by passing `Val{false}()` as an additional constructor
+Renormalization can be skipped by passing `false` as an additional constructor
 argument, in which case the user provides the guarantee that the input arguments
 represent a normalized rotation axis. Operations on an `AngleAxis` with a rotation
 axis that does not have unit norm, created by skipping renormalization in this fashion,
@@ -26,8 +26,8 @@ struct AngleAxis{T} <: Rotation{3,T}
     axis_y::T
     axis_z::T
 
-    @inline function AngleAxis{T}(θ, x, y, z, ::Val{Normalize} = Val{true}()) where {T, Normalize}
-        if Normalize
+    @inline function AngleAxis{T}(θ, x, y, z, normalize::Bool = true) where {T}
+        if normalize
             # Not sure what to do with theta?? Should it become theta * norm ?
             norm = sqrt(x*x + y*y + z*z)
             new(θ, x/norm, y/norm, z/norm)
@@ -39,7 +39,7 @@ end
 
 # StaticArrays will take over *all* the constructors and put everything in a tuple...
 # but this isn't quite what we mean when we have 4 inputs (not 9).
-@inline function AngleAxis(θ::Θ, x::X, y::Y, z::Z, normalize::Val = Val{true}()) where {Θ,X,Y,Z}
+@inline function AngleAxis(θ::Θ, x::X, y::Y, z::Z, normalize::Bool = true) where {Θ,X,Y,Z}
     AngleAxis{promote_type(promote_type(promote_type(Θ, X), Y), Z)}(θ, x, y, z, normalize)
 end
 

--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -10,6 +10,15 @@ arbitrary axis `[x, y, z]`.
 Note that the axis is not unique for θ = 0, and that this parameterization does
 not continuously map the neighbourhood of the null rotation (and therefore
 might not be suitable for autodifferentation and optimization purposes).
+
+Note: by default, the constructor will renormalize the input so that the axis
+has length 1 (x² + y² + z² = 1).
+
+Renormalization can be skipped by passing `Val{false}()` as an additional constructor
+argument, in which case the user provides the guarantee that the input arguments
+represent a normalized rotation axis. Operations on an `AngleAxis` with a rotation
+axis that does not have unit norm, created by skipping renormalization in this fashion,
+are not guaranteed to do anything sensible.
 """
 struct AngleAxis{T} <: Rotation{3,T}
     theta::T
@@ -17,17 +26,22 @@ struct AngleAxis{T} <: Rotation{3,T}
     axis_y::T
     axis_z::T
 
-    # Ensure axis is normalized
-    function AngleAxis{T}(θ, x, y, z) where T
-        norm = sqrt(x*x + y*y + z*z)
-        # Not sure what to do with theta?? Should it become theta * norm ?
-        new(θ, x/norm, y/norm, z/norm)
+    @inline function AngleAxis{T}(θ, x, y, z, ::Val{Normalize} = Val{true}()) where {T, Normalize}
+        if Normalize
+            # Not sure what to do with theta?? Should it become theta * norm ?
+            norm = sqrt(x*x + y*y + z*z)
+            new(θ, x/norm, y/norm, z/norm)
+        else
+            new(θ, x, y, z)
+        end
     end
 end
 
 # StaticArrays will take over *all* the constructors and put everything in a tuple...
 # but this isn't quite what we mean when we have 4 inputs (not 9).
-@inline (::Type{AngleAxis}){Θ,X,Y,Z}(θ::Θ, x::X, y::Y, z::Z) = AngleAxis{promote_type(promote_type(promote_type(Θ, X), Y), Z)}(θ, x, y, z)
+@inline function AngleAxis(θ::Θ, x::X, y::Y, z::Z, normalize::Val = Val{true}()) where {Θ,X,Y,Z}
+    AngleAxis{promote_type(promote_type(promote_type(Θ, X), Y), Z)}(θ, x, y, z, normalize)
+end
 
 # These 2 functions are enough to satisfy the entire StaticArrays interface:
 @inline (::Type{AA}){AA <: AngleAxis}(t::NTuple{9}) = AA(Quat(t))

--- a/src/quaternion_types.jl
+++ b/src/quaternion_types.jl
@@ -10,7 +10,7 @@ through matrix-vector multiplication.
 Note: by default, the constructor will renormalize the input so that the quaternion
 has length 1 (w² + x² + y² + z² = 1), and the rotation matrix is orthogonal.
 
-Renormalization can be skipped by passing `Val{false}()` as an additional constructor
+Renormalization can be skipped by passing `false` as an additional constructor
 argument, in which case the user provides the guarantee that the input arguments
 represent a unit quaternion. Operations on an unnormalized `Quat`, created by
 skipping renormalization in this fashion, are not guaranteed to do anything sensible.
@@ -21,8 +21,8 @@ struct Quat{T} <: Rotation{3,T}
     y::T
     z::T
 
-    @inline function Quat{T}(w, x, y, z, ::Val{Normalize} = Val{true}()) where {T, Normalize}
-        if Normalize
+    @inline function Quat{T}(w, x, y, z, normalize::Bool = true) where {T}
+        if normalize
             norm = copysign(sqrt(w*w + x*x + y*y + z*z), w)
             new(w/norm, x/norm, y/norm, z/norm)
         else
@@ -33,7 +33,7 @@ struct Quat{T} <: Rotation{3,T}
     Quat{T}(q::Quat) where {T} = new{T}(q.w, q.x, q.y, q.z)
 end
 
-@inline function Quat(w::W, x::X, y::Y, z::Z, normalize::Val = Val{true}()) where {W, X, Y, Z}
+@inline function Quat(w::W, x::X, y::Y, z::Z, normalize::Bool = true) where {W, X, Y, Z}
     Quat{promote_type(promote_type(promote_type(W, X), Y), Z)}(w, x, y, z, normalize)
 end
 @inline Quat(q::Quat{T}) where {T} = Quat{T}(q)

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -271,13 +271,13 @@ all_types = (RotMatrix{3}, Quat, SPQuat, AngleAxis, RodriguesVec,
         θ, x, y, z = 1., 2., 3., 4.
         aa = AngleAxis(θ, x, y, z)
         @test norm([aa.axis_x, aa.axis_y, aa.axis_z]) ≈ 1.
-        aa = AngleAxis(θ, x, y, z, Val{false}())
+        aa = AngleAxis(θ, x, y, z, false)
         @test norm([aa.axis_x, aa.axis_y, aa.axis_z]) ≈ norm([x, y, z])
 
         w, x, y, z = 1., 2., 3., 4.
         quat = Quat(w, x, y, z)
         @test norm([quat.w, quat.x, quat.y, quat.z]) ≈ 1.
-        quat = Quat(w, x, y, z, Val{false}())
+        quat = Quat(w, x, y, z, false)
         @test norm([quat.w, quat.x, quat.y, quat.z]) ≈ norm([w, x, y, z])
     end
 end

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -266,4 +266,18 @@ all_types = (RotMatrix{3}, Quat, SPQuat, AngleAxis, RodriguesVec,
         @test eye(RotMatrix{2, Float64}) isa RotMatrix2{Float64}
         @test eye(RotMatrix{3, Float64}) isa RotMatrix3{Float64}
     end
+
+    @testset "Testing normalization" begin
+        θ, x, y, z = 1., 2., 3., 4.
+        aa = AngleAxis(θ, x, y, z)
+        @test norm([aa.axis_x, aa.axis_y, aa.axis_z]) ≈ 1.
+        aa = AngleAxis(θ, x, y, z, Val{false}())
+        @test norm([aa.axis_x, aa.axis_y, aa.axis_z]) ≈ norm([x, y, z])
+
+        w, x, y, z = 1., 2., 3., 4.
+        quat = Quat(w, x, y, z)
+        @test norm([quat.w, quat.x, quat.y, quat.z]) ≈ 1.
+        quat = Quat(w, x, y, z, Val{false}())
+        @test norm([quat.w, quat.x, quat.y, quat.z]) ≈ norm([w, x, y, z])
+    end
 end


### PR DESCRIPTION
I've noticed that the renormalization in `AngleAxis` now accounts for a nontrivial percentage of time spent in my kinematics code, even though I know for sure that the axis I pass in is a unit vector. In addition, there could be scalar types for which normalization is not desired (see https://github.com/tkoolen/RigidBodyDynamics.jl/issues/87). This PR adds the option to skip the normalization in the constructor.

I checked that the generated code is the same as it was before for calls to `Quat(w, x, y, z)` and `AngleAxis(theta, x, y, z)`. This required an `@inline` annotation for the inner constructors.