### PR TITLE
Add missing Tuple constructor

### DIFF
--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -93,11 +93,11 @@ for N = 2:3
     end
 end
 Base.@propagate_inbounds Base.getindex(r::RotMatrix, i::Int) = r.mat[i]
+@inline Tuple(r::RotMatrix) = Tuple(r.mat)
 
 @inline (::Type{RotMatrix})(θ::Real) = RotMatrix(@SMatrix [cos(θ) -sin(θ); sin(θ) cos(θ)])
 @inline (::Type{RotMatrix{2}})(θ::Real)      = RotMatrix(@SMatrix [cos(θ) -sin(θ); sin(θ) cos(θ)])
 @inline (::Type{RotMatrix{2,T}}){T}(θ::Real) = RotMatrix(@SMatrix T[cos(θ) -sin(θ); sin(θ) cos(θ)])
-@inline Tuple(r::RotMatrix) = Tuple(r.mat)
 
 # A rotation is more-or-less defined as being an orthogonal (or unitary) matrix
 Base.inv(r::RotMatrix) = RotMatrix(r.mat')

--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -97,6 +97,7 @@ Base.@propagate_inbounds Base.getindex(r::RotMatrix, i::Int) = r.mat[i]
 @inline (::Type{RotMatrix})(θ::Real) = RotMatrix(@SMatrix [cos(θ) -sin(θ); sin(θ) cos(θ)])
 @inline (::Type{RotMatrix{2}})(θ::Real)      = RotMatrix(@SMatrix [cos(θ) -sin(θ); sin(θ) cos(θ)])
 @inline (::Type{RotMatrix{2,T}}){T}(θ::Real) = RotMatrix(@SMatrix T[cos(θ) -sin(θ); sin(θ) cos(θ)])
+@inline Tuple(r::RotMatrix) = Tuple(r.mat)
 
 # A rotation is more-or-less defined as being an orthogonal (or unitary) matrix
 Base.inv(r::RotMatrix) = RotMatrix(r.mat')

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -280,4 +280,9 @@ all_types = (RotMatrix{3}, Quat, SPQuat, AngleAxis, RodriguesVec,
         quat = Quat(w, x, y, z, false)
         @test norm([quat.w, quat.x, quat.y, quat.z]) ≈ norm([w, x, y, z])
     end
+
+    @testset "Testing RotMatrix conversion to Tuple" begin
+        rot = eye(RotMatrix{3, Float64})
+        @inferred Tuple(rot)
+    end
 end


### PR DESCRIPTION
Before this PR, the fallback `Tuple` constructor in `Base` was being called, causing type instability. This in turn caused conversions from `RotMatrix` to other rotation types to be extremely slow.

Looks like the regression happened when adding support for StaticArrays 0.4.0 (https://github.com/FugroRoames/Rotations.jl/pull/25), i.e. my fault. I should have tested performance as part of that PR. Perhaps this suggests that a proper set of benchmarks should be created at some point.