### PR TITLE
Add basic benchmarks and fix some performance issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+perf/benchmarkparams.jld

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ julia:
   - nightly
 notifications:
   email: false
-# matrix:
-#   allow_failures:
-#     - julia: nightly
+matrix:
+  allow_failures:
+    - julia: nightly
 #     - os: osx
 # uncomment the following lines to override the default test script
 #script:

--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -10,9 +10,11 @@ srand(1)
 suite["conversions"] = BenchmarkGroup()
 rotationtypes = (RotMatrix3{T}, Quat{T}, SPQuat{T}, AngleAxis{T}, RodriguesVec{T})
 for (from, to) in product(rotationtypes, rotationtypes)
-    name = "$(string(from)) -> $(string(to))"
-    # use eval here because of https://github.com/JuliaCI/BenchmarkTools.jl/issues/50#issuecomment-318673288
-    suite["conversions"][name] = eval(:(@benchmarkable convert($to, rot) setup = rot = rand($from)))
+    if from != to
+        name = "$(string(from)) -> $(string(to))"
+        # use eval here because of https://github.com/JuliaCI/BenchmarkTools.jl/issues/50#issuecomment-318673288
+        suite["conversions"][name] = eval(:(@benchmarkable convert($to, rot) setup = rot = rand($from)))
+    end
 end
 
 paramspath = joinpath(dirname(@__FILE__), "benchmarkparams.jld")

--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -1,0 +1,31 @@
+using Rotations
+using BenchmarkTools
+import Base.Iterators: product
+
+const T = Float64
+
+const suite = BenchmarkGroup()
+srand(1)
+
+suite["conversions"] = BenchmarkGroup()
+rotationtypes = (RotMatrix3{T}, Quat{T}, SPQuat{T}, AngleAxis{T}, RodriguesVec{T})
+for (from, to) in product(rotationtypes, rotationtypes)
+    name = "$(string(from)) -> $(string(to))"
+    # use eval here because of https://github.com/JuliaCI/BenchmarkTools.jl/issues/50#issuecomment-318673288
+    suite["conversions"][name] = eval(:(@benchmarkable convert($to, rot) setup = rot = rand($from)))
+end
+
+paramspath = joinpath(dirname(@__FILE__), "benchmarkparams.jld")
+if isfile(paramspath)
+    loadparams!(suite, BenchmarkTools.load(paramspath, "suite"), :evals);
+else
+    tune!(suite, verbose = true)
+    BenchmarkTools.save(paramspath, "suite", params(suite))
+end
+
+results = run(suite, verbose=true)
+for result in results["conversions"]
+    println("$(first(result)):")
+    display(minimum(last(result)))
+    println()
+end

--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -43,9 +43,10 @@ end
     AngleAxis{promote_type(promote_type(promote_type(Θ, X), Y), Z)}(θ, x, y, z, normalize)
 end
 
-# These 2 functions are enough to satisfy the entire StaticArrays interface:
+# These functions are enough to satisfy the entire StaticArrays interface:
 @inline (::Type{AA}){AA <: AngleAxis}(t::NTuple{9}) = AA(Quat(t))
 @inline Base.getindex(aa::AngleAxis, i::Int) = Quat(aa)[i]
+@inline Tuple(aa::AngleAxis) = Tuple(Quat(aa))
 
 @inline function Base.convert{R <: RotMatrix}(::Type{R}, aa::AngleAxis)
     # Rodrigues' rotation formula.
@@ -85,8 +86,6 @@ end
     theta =  2 * atan2(s, q.w)
     return s > 0 ? AA(theta, q.x / s, q.y / s, q.z / s) : AA(theta, one(theta), zero(theta), zero(theta))
 end
-
-@inline Base.convert(::Type{Tuple}, aa::AngleAxis) = Tuple(Quat(aa))
 
 # Using Rodrigues formula on an AngleAxis parameterization (assume unit axis length) to do the rotation
 # (implementation from: https://ceres-solver.googlesource.com/ceres-solver/+/1.10.0/include/ceres/rotation.h)
@@ -147,9 +146,10 @@ end
 # but this isn't quite what we mean when we have 4 inputs (not 9).
 @inline (::Type{RodriguesVec}){X,Y,Z}(x::X, y::Y, z::Z) = RodriguesVec{promote_type(promote_type(X, Y), Z)}(x, y, z)
 
-# These 2 functions are enough to satisfy the entire StaticArrays interface:
+# These functions are enough to satisfy the entire StaticArrays interface:
 @inline (::Type{RV}){RV <: RodriguesVec}(t::NTuple{9}) = RV(Quat(t))
 @inline Base.getindex(aa::RodriguesVec, i::Int) = Quat(aa)[i]
+@inline Tuple(rv::RodriguesVec) = Tuple(Quat(rv))
 
 # define its interaction with other angle representations
 @inline Base.convert{R <: RotMatrix}(::Type{R}, rv::RodriguesVec) = convert(R, AngleAxis(rv))
@@ -180,7 +180,6 @@ function Base.convert{RV <: RodriguesVec}(::Type{RV}, q::Quat)
     return RV(sc * q.x, sc * q.y, sc * q.z )
 end
 
-@inline Base.convert(::Type{Tuple}, rv::RodriguesVec) = Tuple(Quat(rv))
 
 function Base.:*{T1,T2}(rv::RodriguesVec{T1}, v::StaticVector{T2})
     if length(v) != 3

--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -174,13 +174,9 @@ end
 
 function Base.convert{RV <: RodriguesVec}(::Type{RV}, q::Quat)
     s2 = q.x*q.x + q.y*q.y + q.z*q.z
-    if (s2 > 0)
-        cos_t2 = sqrt(s2)
-        theta = 2 * atan2(cos_t2, q.w)
-        sc = theta / cos_t2
-    else
-        sc = 2                 # N.B. the 2 "should" match the derivitive as cos_t2 -> 0
-    end
+    cos_t2 = sqrt(s2)
+    theta = 2 * atan2(cos_t2, q.w)
+    sc = ifelse(cos_t2 > 0, promote(theta / cos_t2, 2)...) # N.B. the 2 "should" match the derivitive as cos_t2 -> 0
     return RV(sc * q.x, sc * q.y, sc * q.z )
 end
 

--- a/src/quaternion_types.jl
+++ b/src/quaternion_types.jl
@@ -41,7 +41,7 @@ end
 @inline convert(::Type{Q}, q::Quat) where {Q<:Quat} = Q(q)
 @inline convert(::Type{Q}, q::Q) where {Q<:Quat} = q
 
-# These 2 functions are enough to satisfy the entire StaticArrays interface:
+# These 3 functions are enough to satisfy the entire StaticArrays interface:
 function (::Type{Q}){Q<:Quat}(t::NTuple{9})
     q = Q(sqrt(abs(1  + t[1] + t[5] + t[9])) / 2,
                copysign(sqrt(abs(1 + t[1] - t[5] - t[9]))/2, t[6] - t[8]),
@@ -106,8 +106,7 @@ function Base.getindex(q::Quat, i::Int)
     end
 end
 
-# This speeds up some StaticArray methods (such as conversion to RotMatrix)
-function Base.convert(::Type{Tuple}, q::Quat)
+function Tuple(q::Quat)
     ww = (q.w * q.w)
     xx = (q.x * q.x)
     yy = (q.y * q.y)
@@ -219,9 +218,10 @@ end
 @inline convert(::Type{SPQ}, spq::SPQuat) where {SPQ<:SPQuat} = SPQ(spq)
 @inline convert(::Type{SPQ}, spq::SPQ) where {SPQ<:SPQuat} = spq
 
-# These 2 functions are enough to satisfy the entire StaticArrays interface:
+# These functions are enough to satisfy the entire StaticArrays interface:
 @inline (::Type{SPQ}){SPQ <: SPQuat}(t::NTuple{9}) = SPQ(Quat(t))
 @inline Base.getindex(spq::SPQuat, i::Int) = Quat(spq)[i]
+@inline Tuple(spq::SPQuat) = Tuple(Quat(spq))
 
 @inline function Base.convert{Q <: Quat}(::Type{Q}, spq::SPQuat)
     # Both the sign and norm of the Quat is automatically dealt with in its inner constructor
@@ -232,8 +232,6 @@ end
     alpha2 = (1 - q.w) / (1 + q.w) # <= 1 since q.w >= 0
     spq = SPQ(q.x * (alpha2 + 1)*0.5,  q.y * (alpha2 + 1)*0.5, q.z * (alpha2 + 1)*0.5)
 end
-
-@inline Base.convert(::Type{Tuple}, spq::SPQuat) = Tuple(Quat(spq))
 
 @inline Base.:*(spq::SPQuat, x::StaticVector) = Quat(spq) * x
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 ForwardDiff
+BenchmarkTools

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,3 +13,5 @@ include("util_tests.jl")
 include("2d.jl")
 include("rotation_tests.jl")
 include("derivative_tests.jl")
+
+include(joinpath("..", "perf", "runbenchmarks.jl"))


### PR DESCRIPTION
Add some basic rotation type conversion benchmarks. Output as of right now:
```
Rotations.SPQuat{Float64} -> Rotations.RodriguesVec{Float64}:
BenchmarkTools.TrialEstimate: 
  time:             859.833 ns
  gctime:           0.000 ns (0.00%)
  memory:           752 bytes
  allocs:           24
Rotations.SPQuat{Float64} -> Rotations.SPQuat{Float64}:
BenchmarkTools.TrialEstimate: 
  time:             1.730 ns
  gctime:           0.000 ns (0.00%)
  memory:           0 bytes
  allocs:           0
Rotations.SPQuat{Float64} -> Rotations.AngleAxis{Float64}:
BenchmarkTools.TrialEstimate: 
  time:             806.691 ns
  gctime:           0.000 ns (0.00%)
  memory:           624 bytes
  allocs:           15
Rotations.RodriguesVec{Float64} -> Rotations.Quat{Float64}:
BenchmarkTools.TrialEstimate: 
  time:             36.798 ns
  gctime:           0.000 ns (0.00%)
  memory:           0 bytes
  allocs:           0
Rotations.Quat{Float64} -> Rotations.RodriguesVec{Float64}:
BenchmarkTools.TrialEstimate: 
  time:             84.546 ns
  gctime:           0.000 ns (0.00%)
  memory:           144 bytes
  allocs:           9
Rotations.Quat{Float64} -> Rotations.AngleAxis{Float64}:
BenchmarkTools.TrialEstimate: 
  time:             21.316 ns
  gctime:           0.000 ns (0.00%)
  memory:           0 bytes
  allocs:           0
Rotations.AngleAxis{Float64} -> Rotations.SPQuat{Float64}:
BenchmarkTools.TrialEstimate: 
  time:             916.097 ns
  gctime:           0.000 ns (0.00%)
  memory:           608 bytes
  allocs:           15
Rotations.Quat{Float64} -> Rotations.Quat{Float64}:
BenchmarkTools.TrialEstimate: 
  time:             1.783 ns
  gctime:           0.000 ns (0.00%)
  memory:           0 bytes
  allocs:           0
Rotations.SPQuat{Float64} -> Rotations.Quat{Float64}:
BenchmarkTools.TrialEstimate: 
  time:             8.377 ns
  gctime:           0.000 ns (0.00%)
  memory:           0 bytes
  allocs:           0
Rotations.Quat{Float64} -> Rotations.SPQuat{Float64}:
BenchmarkTools.TrialEstimate: 
  time:             2.964 ns
  gctime:           0.000 ns (0.00%)
  memory:           0 bytes
  allocs:           0
Rotations.RotMatrix{3,Float64,9} -> Rotations.Quat{Float64}:
BenchmarkTools.TrialEstimate: 
  time:             16.981 ns
  gctime:           0.000 ns (0.00%)
  memory:           0 bytes
  allocs:           0
Rotations.RotMatrix{3,Float64,9} -> Rotations.AngleAxis{Float64}:
BenchmarkTools.TrialEstimate: 
  time:             57.857 ns
  gctime:           0.000 ns (0.00%)
  memory:           0 bytes
  allocs:           0
Rotations.RotMatrix{3,Float64,9} -> Rotations.RotMatrix{3,Float64,9}:
BenchmarkTools.TrialEstimate: 
  time:             2.080 ns
  gctime:           0.000 ns (0.00%)
  memory:           0 bytes
  allocs:           0
Rotations.AngleAxis{Float64} -> Rotations.RodriguesVec{Float64}:
BenchmarkTools.TrialEstimate: 
  time:             1.730 ns
  gctime:           0.000 ns (0.00%)
  memory:           0 bytes
  allocs:           0
Rotations.RodriguesVec{Float64} -> Rotations.AngleAxis{Float64}:
BenchmarkTools.TrialEstimate: 
  time:             13.116 ns
  gctime:           0.000 ns (0.00%)
  memory:           0 bytes
  allocs:           0
Rotations.RodriguesVec{Float64} -> Rotations.RotMatrix{3,Float64,9}:
BenchmarkTools.TrialEstimate: 
  time:             31.930 ns
  gctime:           0.000 ns (0.00%)
  memory:           0 bytes
  allocs:           0
Rotations.RodriguesVec{Float64} -> Rotations.SPQuat{Float64}:
BenchmarkTools.TrialEstimate: 
  time:             1.080 μs
  gctime:           0.000 ns (0.00%)
  memory:           608 bytes
  allocs:           15
Rotations.RodriguesVec{Float64} -> Rotations.RodriguesVec{Float64}:
BenchmarkTools.TrialEstimate: 
  time:             1.450 ns
  gctime:           0.000 ns (0.00%)
  memory:           0 bytes
  allocs:           0
Rotations.Quat{Float64} -> Rotations.RotMatrix{3,Float64,9}:
BenchmarkTools.TrialEstimate: 
  time:             645.228 ns
  gctime:           0.000 ns (0.00%)
  memory:           656 bytes
  allocs:           15
Rotations.AngleAxis{Float64} -> Rotations.RotMatrix{3,Float64,9}:
BenchmarkTools.TrialEstimate: 
  time:             15.995 ns
  gctime:           0.000 ns (0.00%)
  memory:           0 bytes
  allocs:           0
Rotations.AngleAxis{Float64} -> Rotations.AngleAxis{Float64}:
BenchmarkTools.TrialEstimate: 
  time:             1.451 ns
  gctime:           0.000 ns (0.00%)
  memory:           0 bytes
  allocs:           0
Rotations.RotMatrix{3,Float64,9} -> Rotations.SPQuat{Float64}:
BenchmarkTools.TrialEstimate: 
  time:             22.274 ns
  gctime:           0.000 ns (0.00%)
  memory:           0 bytes
  allocs:           0
Rotations.SPQuat{Float64} -> Rotations.RotMatrix{3,Float64,9}:
BenchmarkTools.TrialEstimate: 
  time:             791.435 ns
  gctime:           0.000 ns (0.00%)
  memory:           656 bytes
  allocs:           15
Rotations.AngleAxis{Float64} -> Rotations.Quat{Float64}:
BenchmarkTools.TrialEstimate: 
  time:             20.048 ns
  gctime:           0.000 ns (0.00%)
  memory:           0 bytes
  allocs:           0
Rotations.RotMatrix{3,Float64,9} -> Rotations.RodriguesVec{Float64}:
BenchmarkTools.TrialEstimate: 
  time:             115.546 ns
  gctime:           0.000 ns (0.00%)
  memory:           144 bytes
  allocs:           9
```
Just quickly examining these results, I found:
* `RodriguesVec` and `SPQuat` have the same issue as https://github.com/FugroRoames/Rotations.jl/pull/38
* conversion from `Quat` to `RotMatrix` calls `Tuple` constructor in `StaticArrays` code. `Rotations` defines a `convert` method from `Quat` to `Tuple`, but calling the `Tuple` constructor doesn't call this `convert` method.
* `Quat` -> `RodriguesVec` is type unstable (variable `sc`)

