### PR TITLE
changed dcm to quaternion function

### DIFF
--- a/src/quaternion_types.jl
+++ b/src/quaternion_types.jl
@@ -43,42 +43,42 @@ end
 
 # These 3 functions are enough to satisfy the entire StaticArrays interface:
 function (::Type{Q})(t::NTuple{9}) where Q<:Quat
-  #=
-  This function solves the system of equations in Section 3.1
-  of https://arxiv.org/pdf/math/0701759.pdf. This cheap method
-  only works for matrices that are already orthonormal (orthogonal
-  and unit length columns). The nearest orthonormal matrix can
-  be found by solving Wahba's problem:
-  https://en.wikipedia.org/wiki/Wahba%27s_problem as shown below.
+    #=
+    This function solves the system of equations in Section 3.1
+    of https://arxiv.org/pdf/math/0701759.pdf. This cheap method
+    only works for matrices that are already orthonormal (orthogonal
+    and unit length columns). The nearest orthonormal matrix can
+    be found by solving Wahba's problem:
+    https://en.wikipedia.org/wiki/Wahba%27s_problem as shown below.
 
-  not_orthogonal = randn(3,3)
-  u,s,v = svd(not_orthogonal)
-  is_orthogoral = u * diagm([1, 1, sign(det(u * v.'))]) * v.'
-  =#
+    not_orthogonal = randn(3,3)
+    u,s,v = svd(not_orthogonal)
+    is_orthogoral = u * diagm([1, 1, sign(det(u * v.'))]) * v.'
+    =#
 
-  a = 1 + t[1] + t[5] + t[9]
-  b = 1 + t[1] - t[5] - t[9]
-  c = 1 - t[1] + t[5] - t[9]
-  d = 1 - t[1] - t[5] + t[9]
-  max_abcd = max(a, b, c, d)
-  if a == max_abcd
-    b = t[6] - t[8]
-    c = t[7] - t[3]
-    d = t[2] - t[4]
-  elseif b == max_abcd
-    a = t[6] - t[8]
-    c = t[2] + t[4]
-    d = t[7] + t[3]
-  elseif c == max_abcd
-    a = t[7] - t[3]
-    b = t[2] + t[4]
-    d = t[6] + t[8]
-  else
-    a = t[2] - t[4]
-    b = t[7] + t[3]
-    c = t[6] + t[8]
-  end
-  return Q(a, b, c, d)
+    a = 1 + t[1] + t[5] + t[9]
+    b = 1 + t[1] - t[5] - t[9]
+    c = 1 - t[1] + t[5] - t[9]
+    d = 1 - t[1] - t[5] + t[9]
+    max_abcd = max(a, b, c, d)
+    if a == max_abcd
+        b = t[6] - t[8]
+        c = t[7] - t[3]
+        d = t[2] - t[4]
+    elseif b == max_abcd
+        a = t[6] - t[8]
+        c = t[2] + t[4]
+        d = t[7] + t[3]
+    elseif c == max_abcd
+        a = t[7] - t[3]
+        b = t[2] + t[4]
+        d = t[6] + t[8]
+    else
+        a = t[2] - t[4]
+        b = t[7] + t[3]
+        c = t[6] + t[8]
+    end
+    return Q(a, b, c, d)
 end
 
 

--- a/src/quaternion_types.jl
+++ b/src/quaternion_types.jl
@@ -43,10 +43,45 @@ end
 
 # These 3 functions are enough to satisfy the entire StaticArrays interface:
 function (::Type{Q})(t::NTuple{9}) where Q<:Quat
-    q = Q(sqrt(abs(1  + t[1] + t[5] + t[9])) / 2,
-               copysign(sqrt(abs(1 + t[1] - t[5] - t[9]))/2, t[6] - t[8]),
-               copysign(sqrt(abs(1 - t[1] + t[5] - t[9]))/2, t[7] - t[3]),
-               copysign(sqrt(abs(1 - t[1] - t[5] + t[9]))/2, t[2] - t[4]))
+  """
+  DERIVATION OF THE EULER–RODRIGUES FORMULA
+  FOR THREE-DIMENSIONAL ROTATIONS
+  FROM THE GENERAL FORMULA
+  FOR FOUR-DIMENSIONAL ROTATIONS
+  Johan Ernest Mebius∗
+  January 2007
+
+  https://arxiv.org/pdf/math/0701759.pdf
+  This solves the system of equations in Section 3.1
+  """
+
+  a = 1.0 + t[1] + t[5] + t[9]
+  b = 1.0 + t[1] - t[5] - t[9]
+  c = 1.0 - t[1] + t[5] - t[9]
+  d = 1.0 - t[1] - t[5] + t[9]
+  maxABCD = max(a, b, c, d)
+  if a == maxABCD
+    divTerm = 0.5 / sqrt(a)
+    b = t[6] - t[8]
+    c = t[7] - t[3]
+    d = t[2] - t[4]
+  elseif b == maxABCD
+    a = t[6] - t[8]
+    divTerm = 0.5 / sqrt(b)
+    c = t[2] + t[4]
+    d = t[7] + t[3]
+  elseif c == maxABCD
+    a = t[7] - t[3]
+    b = t[2] + t[4]
+    divTerm = 0.5 / sqrt(c)
+    d = t[6] + t[8]
+  else  # iMax == 4
+    a = t[2] - t[4]
+    b = t[7] + t[3]
+    c = t[6] + t[8]
+    divTerm = 0.5 / sqrt(d)
+  end
+  return Q(a * divTerm, b * divTerm, c * divTerm, d * divTerm)
 end
 
 function Base.getindex(q::Quat, i::Int)

--- a/src/quaternion_types.jl
+++ b/src/quaternion_types.jl
@@ -44,45 +44,43 @@ end
 # These 3 functions are enough to satisfy the entire StaticArrays interface:
 function (::Type{Q})(t::NTuple{9}) where Q<:Quat
   """
-  DERIVATION OF THE EULER–RODRIGUES FORMULA
-  FOR THREE-DIMENSIONAL ROTATIONS
-  FROM THE GENERAL FORMULA
-  FOR FOUR-DIMENSIONAL ROTATIONS
-  Johan Ernest Mebius∗
-  January 2007
+  This function solves the system of equations in Section 3.1
+  of https://arxiv.org/pdf/math/0701759.pdf. This cheap method
+  only works for matrices that are already orthonormal (orthogonal
+  and unit length columns). The nearest orthonormal matrix can
+  be found by solving Wahba's problem:
+  https://en.wikipedia.org/wiki/Wahba%27s_problem as shown below.
 
-  https://arxiv.org/pdf/math/0701759.pdf
-  This solves the system of equations in Section 3.1
+  not_orthogonal = randn(3,3)
+  u,s,v = svd(not_orthogonal)
+  is_orthogoral = u * diagm([1, 1, sign(det(u * v.'))]) * v.'
   """
 
-  a = 1.0 + t[1] + t[5] + t[9]
-  b = 1.0 + t[1] - t[5] - t[9]
-  c = 1.0 - t[1] + t[5] - t[9]
-  d = 1.0 - t[1] - t[5] + t[9]
-  maxABCD = max(a, b, c, d)
-  if a == maxABCD
-    divTerm = 0.5 / sqrt(a)
+  a = 1 + t[1] + t[5] + t[9]
+  b = 1 + t[1] - t[5] - t[9]
+  c = 1 - t[1] + t[5] - t[9]
+  d = 1 - t[1] - t[5] + t[9]
+  max_abcd = max(a, b, c, d)
+  if a == max_abcd
     b = t[6] - t[8]
     c = t[7] - t[3]
     d = t[2] - t[4]
-  elseif b == maxABCD
+  elseif b == max_abcd
     a = t[6] - t[8]
-    divTerm = 0.5 / sqrt(b)
     c = t[2] + t[4]
     d = t[7] + t[3]
-  elseif c == maxABCD
+  elseif c == max_abcd
     a = t[7] - t[3]
     b = t[2] + t[4]
-    divTerm = 0.5 / sqrt(c)
     d = t[6] + t[8]
-  else  # iMax == 4
+  else
     a = t[2] - t[4]
     b = t[7] + t[3]
     c = t[6] + t[8]
-    divTerm = 0.5 / sqrt(d)
   end
-  return Q(a * divTerm, b * divTerm, c * divTerm, d * divTerm)
+  return Q(a, b, c, d)
 end
+
 
 function Base.getindex(q::Quat, i::Int)
     if i == 1

--- a/src/quaternion_types.jl
+++ b/src/quaternion_types.jl
@@ -43,7 +43,7 @@ end
 
 # These 3 functions are enough to satisfy the entire StaticArrays interface:
 function (::Type{Q})(t::NTuple{9}) where Q<:Quat
-  """
+  #=
   This function solves the system of equations in Section 3.1
   of https://arxiv.org/pdf/math/0701759.pdf. This cheap method
   only works for matrices that are already orthonormal (orthogonal
@@ -54,7 +54,7 @@ function (::Type{Q})(t::NTuple{9}) where Q<:Quat
   not_orthogonal = randn(3,3)
   u,s,v = svd(not_orthogonal)
   is_orthogoral = u * diagm([1, 1, sign(det(u * v.'))]) * v.'
-  """
+  =#
 
   a = 1 + t[1] + t[5] + t[9]
   b = 1 + t[1] - t[5] - t[9]

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -182,19 +182,18 @@ all_types = (RotMatrix{3}, Quat, SPQuat, AngleAxis, RodriguesVec,
     # Test robustness of DCM to Quat function
     #########################################################################
     function nearest_orthonormal(not_orthonormal)
-      # Didn't see a function like this already in Rotations
-      u,s,v = svd(not_orthonormal)
-      return u * diagm([1, 1, sign(det(u * v.'))]) * v.'
+        u,s,v = svd(not_orthonormal)
+        return u * diagm([1, 1, sign(det(u * v.'))]) * v.'
     end
 
     @testset "DCM to Quat" begin
-      pert = 1e-3
-      for type_rot in all_types
-        for _ = 1:100
-          not_orthonormal = rand(type_rot) + rand(3, 3) * pert
-          @test norm(Quat(not_orthonormal) - nearest_orthonormal(not_orthonormal)) < 10pert
+        pert = 1e-3
+        for type_rot in all_types
+            for _ = 1:100
+                not_orthonormal = rand(type_rot) + rand(3, 3) * pert
+                @test norm(Quat(not_orthonormal) - nearest_orthonormal(not_orthonormal)) < 10pert
+            end
         end
-      end
     end
 
     #########################################################################


### PR DESCRIPTION
For certain matrices the current function gives the wrong answer. For example:
`atMat(x) = [sin(x) 0 cos(x); 0 -1 0; cos(x) 0 -sin(x)]`
`m1 = atMat(3.1)`
[ 0.0415807 0.0 -0.999135;
0.0 -1.0 0.0;
-0.999135 0.0 -0.0415807]
`println(det(m1))` # 1.0
`println(abs(sum(Quat(m1) - m1)))` # 3.9965406116275517