### PR TITLE
Performance tweaks

### DIFF
--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -78,14 +78,14 @@ end
     theta_2 = aa.theta / 2
     c = cos(theta_2)
     s = sin(theta_2)
-    return Q(c, s * aa.axis_x, s * aa.axis_y, s * aa.axis_z)
+    return Q(c, s * aa.axis_x, s * aa.axis_y, s * aa.axis_z, false)
 end
 
 @inline function Base.convert(::Type{AA}, q::Quat) where AA <: AngleAxis
     # TODO: consider how to deal with derivative near theta = 0
     s = sqrt(q.x*q.x + q.y*q.y + q.z*q.z)
     theta =  2 * atan2(s, q.w)
-    return s > 0 ? AA(theta, q.x / s, q.y / s, q.z / s) : AA(theta, one(theta), zero(theta), zero(theta))
+    return s > 0 ? AA(theta, q.x / s, q.y / s, q.z / s, false) : AA(theta, one(theta), zero(theta), zero(theta), false)
 end
 
 # Using Rodrigues formula on an AngleAxis parameterization (assume unit axis length) to do the rotation
@@ -158,7 +158,7 @@ end
 function Base.convert(::Type{AA}, rv::RodriguesVec) where AA <: AngleAxis
     # TODO: consider how to deal with derivative near theta = 0. There should be a first-order expansion here.
     theta = rotation_angle(rv)
-    return theta > 0 ? AA(theta, rv.sx / theta, rv.sy / theta, rv.sz / theta) : AA(zero(theta), one(theta), zero(theta), zero(theta))
+    return theta > 0 ? AA(theta, rv.sx / theta, rv.sy / theta, rv.sz / theta, false) : AA(zero(theta), one(theta), zero(theta), zero(theta), false)
 end
 
 function Base.convert(::Type{RV}, aa::AngleAxis) where RV <: RodriguesVec
@@ -170,7 +170,7 @@ function Base.convert(::Type{Q}, rv::RodriguesVec) where Q <: Quat
     qtheta = cos(theta / 2)
     #s = abs(1/2 * sinc((theta / 2) / pi))
     s = (1/2 * sinc((theta / 2) / pi)) # TODO check this (I removed an abs)
-    return Q(qtheta, s * rv.sx, s * rv.sy, s * rv.sz)
+    return Q(qtheta, s * rv.sx, s * rv.sy, s * rv.sz, false)
 end
 
 function Base.convert(::Type{RV}, q::Quat) where RV <: RodriguesVec

--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -46,7 +46,7 @@ end
 # These functions are enough to satisfy the entire StaticArrays interface:
 @inline (::Type{AA})(t::NTuple{9}) where {AA <: AngleAxis} = AA(Quat(t))
 @inline Base.getindex(aa::AngleAxis, i::Int) = Quat(aa)[i]
-@inline Tuple(aa::AngleAxis) = Tuple(Quat(aa))
+@inline Tuple(aa::AngleAxis) = Tuple(RotMatrix(aa))
 
 @inline function Base.convert(::Type{R}, aa::AngleAxis) where R <: RotMatrix
     # Rodrigues' rotation formula.

--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -75,9 +75,10 @@ end
 end
 
 @inline function Base.convert(::Type{Q}, aa::AngleAxis) where Q <: Quat
-    qtheta = cos(aa.theta / 2)
-    s = sin(aa.theta / 2) / sqrt(aa.axis_x * aa.axis_x + aa.axis_y * aa.axis_y + aa.axis_z * aa.axis_z)
-    return Q(qtheta, s * aa.axis_x, s * aa.axis_y, s * aa.axis_z)
+    theta_2 = aa.theta / 2
+    c = cos(theta_2)
+    s = sin(theta_2)
+    return Q(c, s * aa.axis_x, s * aa.axis_y, s * aa.axis_z)
 end
 
 @inline function Base.convert(::Type{AA}, q::Quat) where AA <: AngleAxis


### PR DESCRIPTION
| Conversion        | Time ratio           | Judgement  |
| ------------- |:-------------:| -----:|
| SPQuat{Float64} -> RodriguesVec{Float64} | +2.90% | invariant |
| SPQuat{Float64} -> AngleAxis{Float64} | -4.02% | invariant |
| RodriguesVec{Float64} -> Quat{Float64} | -21.39% | improvement |
| Quat{Float64} -> RodriguesVec{Float64} | +0.25% | invariant |
| Quat{Float64} -> AngleAxis{Float64} | -13.66% | improvement |
| AngleAxis{Float64} -> SPQuat{Float64} | -30.37% | improvement |
| SPQuat{Float64} -> Quat{Float64} | -2.75% | invariant |
| Quat{Float64} -> SPQuat{Float64} | -0.02% | invariant |
| RotMatrix{3,Float64,9} -> Quat{Float64} | +0.16% | invariant |
| RotMatrix{3,Float64,9} -> AngleAxis{Float64} | -13.99% | improvement |
| AngleAxis{Float64} -> RodriguesVec{Float64} | +0.05% | invariant |
| RodriguesVec{Float64} -> AngleAxis{Float64} | -35.94% | improvement |
| RodriguesVec{Float64} -> SPQuat{Float64} | -7.63% | improvement |
| RodriguesVec{Float64} -> RotMatrix{3,Float64,9} | -20.18% | improvement |
| Quat{Float64} -> RotMatrix{3,Float64,9} | -4.09% | invariant |
| AngleAxis{Float64} -> RotMatrix{3,Float64,9} | +0.21% | invariant |
| RotMatrix{3,Float64,9} -> SPQuat{Float64} | +3.35% | invariant |
| SPQuat{Float64} -> RotMatrix{3,Float64,9} | +0.81% | invariant |
| AngleAxis{Float64} -> Quat{Float64} | -43.42% | improvement |
| RotMatrix{3,Float64,9} -> RodriguesVec{Float64} | +2.75% | invariant |

