### PR TITLE
Fix ambiguity and stackoverflow caused by StaticArrays 0.6.5

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.6
-StaticArrays 0.5
+StaticArrays 0.6.5

--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -44,9 +44,9 @@ end
 end
 
 # These functions are enough to satisfy the entire StaticArrays interface:
-@inline (::Type{AA})(t::NTuple{9}) where {AA <: AngleAxis} = AA(Quat(t))
-@inline Base.getindex(aa::AngleAxis, i::Int) = Quat(aa)[i]
-@inline Tuple(aa::AngleAxis) = Tuple(RotMatrix(aa))
+@inline (::Type{AA})(t::NTuple{9}) where {AA <: AngleAxis} = convert(AA, Quat(t))
+@inline Base.getindex(aa::AngleAxis, i::Int) = convert(Quat, aa)[i]
+@inline Tuple(aa::AngleAxis) = Tuple(convert(RotMatrix, aa))
 
 @inline function Base.convert(::Type{R}, aa::AngleAxis) where R <: RotMatrix
     # Rodrigues' rotation formula.
@@ -148,9 +148,9 @@ end
 @inline (::Type{RodriguesVec})(x::X, y::Y, z::Z) where {X,Y,Z} = RodriguesVec{promote_type(promote_type(X, Y), Z)}(x, y, z)
 
 # These functions are enough to satisfy the entire StaticArrays interface:
-@inline (::Type{RV})(t::NTuple{9}) where {RV <: RodriguesVec} = RV(Quat(t))
-@inline Base.getindex(aa::RodriguesVec, i::Int) = Quat(aa)[i]
-@inline Tuple(rv::RodriguesVec) = Tuple(Quat(rv))
+@inline (::Type{RV})(t::NTuple{9}) where {RV <: RodriguesVec} = convert(RV, Quat(t))
+@inline Base.getindex(aa::RodriguesVec, i::Int) = convert(Quat, aa)[i]
+@inline Tuple(rv::RodriguesVec) = Tuple(convert(Quat, rv))
 
 # define its interaction with other angle representations
 @inline Base.convert(::Type{R}, rv::RodriguesVec) where {R <: RotMatrix} = convert(R, AngleAxis(rv))

--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -76,6 +76,8 @@ Note: the orthonormality of the input matrix is *not* checked by the constructor
 struct RotMatrix{N,T,L} <: Rotation{N,T} # which is <: AbstractMatrix{T}
     mat::SMatrix{N, N, T, L} # The final parameter to SMatrix is the "length" of the matrix, 3 × 3 = 9
     RotMatrix{N,T,L}(x::AbstractArray) where {N,T,L} = new{N,T,L}(convert(SMatrix{N,N,T,L}, x))
+    # fixes #49 ambiguity introduced in StaticArrays 0.6.5
+    RotMatrix{N,T,L}(x::StaticArray) where {N,T,L} = new{N,T,L}(convert(SMatrix{N,N,T,L}, x))
 end
 RotMatrix(x::SMatrix{N,N,T,L}) where {N,T,L} = RotMatrix{N,T,L}(x)
 

--- a/src/quaternion_types.jl
+++ b/src/quaternion_types.jl
@@ -252,9 +252,9 @@ end
 @inline convert(::Type{SPQ}, spq::SPQ) where {SPQ<:SPQuat} = spq
 
 # These functions are enough to satisfy the entire StaticArrays interface:
-@inline (::Type{SPQ})(t::NTuple{9}) where {SPQ <: SPQuat} = SPQ(Quat(t))
-@inline Base.getindex(spq::SPQuat, i::Int) = Quat(spq)[i]
-@inline Tuple(spq::SPQuat) = Tuple(Quat(spq))
+@inline (::Type{SPQ})(t::NTuple{9}) where {SPQ <: SPQuat} = convert(SPQ, Quat(t))
+@inline Base.getindex(spq::SPQuat, i::Int) = convert(Quat, spq)[i]
+@inline Tuple(spq::SPQuat) = Tuple(convert(Quat, spq))
 
 @inline function Base.convert(::Type{Q}, spq::SPQuat) where Q <: Quat
     # Both the sign and norm of the Quat is automatically dealt with in its inner constructor

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,2 @@
 ForwardDiff
-BenchmarkTools
+BenchmarkTools 0.0.0 0.1.0


### PR DESCRIPTION
This fixes #49 and other issues that arose with StaticArrays 0.6.5 (stack overflows caused by https://github.com/JuliaArrays/StaticArrays.jl/blob/master/src/convert.jl#L4).

I also upper bound BenchmarkTools under `test/REQUIRE`, because of this:

```
ERROR: LoadError: LoadError: ArgumentError: JLD serialization is no longer supported. Benchmarks should now be saved in
JSON format using `save("~/.julia/v0.6/Rotations/test/../perf/benchmarkparams".json, args...)` and loaded from JSON using
using `load("~/.julia/v0.6/Rotations/test/../perf/benchmarkparams".json, args...)`. You will need to convert existing
saved benchmarks to JSON in order to use them with this version of BenchmarkTools.
```

Note that I actually just trial-and-errored myself to victory here. While all the test pass, someone should double check that the behaviour is still correct