### PR TITLE
WIP: support for Julia 0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ q2 = rand(Quat)
 q3 = q * q2
 
 # Take the inverse (equivalent to transpose)
-q_inv = q'
+q_inv = transpose(q)
 q_inv == inv(q)
 p ≈ q_inv * (q * p)
 q4 = q3 / q2  # q4 = q3 * inv(q2)
@@ -102,7 +102,7 @@ j2 = Rotations.jacobian(q, p) # How does the rotated point q*p change w.r.t. the
 
 4. **Rodrigues Vector** `RodriguesVec{T}`
 
-    A 3D rotation encoded by an angle-axis representation as `angle * axis`.  
+    A 3D rotation encoded by an angle-axis representation as `angle * axis`.
     This type is used in packages such as [OpenCV](http://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html#void%20Rodrigues%28InputArray%20src,%20OutputArray%20dst,%20OutputArray%20jacobian%29).
 
     Note: If you're differentiating a Rodrigues Vector check the result is what

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.6
 StaticArrays 0.6.5
+Compat

--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -1,6 +1,7 @@
 using Rotations
 using BenchmarkTools
 import Base.Iterators: product
+import Compat.Random: srand
 
 const T = Float64
 
@@ -11,16 +12,23 @@ suite["conversions"] = BenchmarkGroup()
 rotationtypes = (RotMatrix3{T}, Quat{T}, SPQuat{T}, AngleAxis{T}, RodriguesVec{T})
 for (from, to) in product(rotationtypes, rotationtypes)
     if from != to
-        name = "$(string(from)) -> $(string(to))"
+        name = if VERSION < v"0.7.0-"
+            "$(string(from)) -> $(string(to))"
+        else
+            "Rotations.$(string(from)) -> Rotations.$(string(to))"
+        end
         # use eval here because of https://github.com/JuliaCI/BenchmarkTools.jl/issues/50#issuecomment-318673288
         suite["conversions"][name] = eval(:(@benchmarkable convert($to, rot) setup = rot = rand($from)))
     end
 end
 
 suite["composition"] = BenchmarkGroup()
-suite["composition"]["RotMatrix{3} * RotMatrix{3}"] = @benchmarkable r1 * r2 setup = (r1 = rand(RotMatrix3{T}); r2 = rand(RotMatrix3{T}))
+suite["composition"]["RotMatrix{3} * RotMatrix{3}"] = @benchmarkable(
+    r1 * r2,
+    setup = (r1 = rand(RotMatrix3{T}); r2 = rand(RotMatrix3{T}))
+)
 
-paramspath = joinpath(dirname(@__FILE__), "benchmarkparams.json")
+paramspath = joinpath(@__DIR__, "benchmarkparams.json")
 if isfile(paramspath)
     loadparams!(suite, BenchmarkTools.load(paramspath)[1], :evals, :samples);
 else

--- a/src/Rotations.jl
+++ b/src/Rotations.jl
@@ -3,9 +3,12 @@ __precompile__(true)
 
 module Rotations
 
+using Compat
+using Compat.LinearAlgebra
 using StaticArrays
 
-import Base: convert, eltype, size, length, getindex, inv, *, Tuple, eye
+import Base: convert, eltype, size, length, getindex, *, Tuple
+import Compat.LinearAlgebra: inv, eye
 
 include("util.jl")
 include("core_types.jl")

--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -220,5 +220,7 @@ end
 
 # Removes module name from output, to match other types
 function Base.summary(r::Rotation{N,T}) where {T,N}
-    "$N×$N $(typeof(r).name.name){$(eltype(r))}"
+    inds = indices(r)
+    typestring = last(split(string(typeof(r)), '.'; limit = 2))
+    string(Base.dims2string(length.(inds)), " ", typestring)
 end

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -66,7 +66,7 @@ function jacobian(::Type{RotMatrix},  q::Quat)
     #          = (dR(s*q)/dQ*s - s*R(q) * ds/dQ) / s^2
     #          = (dR(s*q)/dQ   - R(q) * ds/dQ) / s
 
-    jac = dsRdQ - R * dsdQ.'
+    jac = dsRdQ - R * transpose(dsdQ)
 
     # now reformat for output.  TODO: is the the best expression?
     # return Vec{4,Mat{3,3,T}}(ith_partial(jac, 1), ith_partial(jac, 2), ith_partial(jac, 3), ith_partial(jac, 4))
@@ -198,7 +198,7 @@ function jacobian(q::Quat, X::AbstractVector)
 
     # and finalize with the quotient rule
     Xo = q * X           # N.B. g(x) = s * Xo, with dG/dx = dRdQs
-    Xom = Xo * dSdQ.'
+    Xom = Xo * transpose(dSdQ)
     return dRdQs -  Xom
 end
 

--- a/src/quaternion_types.jl
+++ b/src/quaternion_types.jl
@@ -53,7 +53,7 @@ function (::Type{Q})(t::NTuple{9}) where Q<:Quat
 
     not_orthogonal = randn(3,3)
     u,s,v = svd(not_orthogonal)
-    is_orthogoral = u * diagm([1, 1, sign(det(u * v.'))]) * v.'
+    is_orthogoral = u * diagm([1, 1, sign(det(u * transpose(v)))]) * transpose(v)
     =#
 
     a = 1 + t[1] + t[5] + t[9]
@@ -188,12 +188,12 @@ function Base.:*(q1::Quat, q2::Quat)
             q1.w*q2.z + q1.x*q2.y - q1.y*q2.x + q1.z*q2.w)
 end
 
-function Base.inv(q::Quat)
+function inv(q::Quat)
     Quat(q.w, -q.x, -q.y, -q.z)
 end
 
-@inline Base.eye(::Type{Quat}) = Quat(1.0, 0.0, 0.0, 0.0)
-@inline Base.eye(::Type{Quat{T}}) where {T} = Quat{T}(one(T), zero(T), zero(T), zero(T))
+@inline eye(::Type{Quat}) = Quat(1.0, 0.0, 0.0, 0.0)
+@inline eye(::Type{Quat{T}}) where {T} = Quat{T}(one(T), zero(T), zero(T), zero(T))
 
 """
     rotation_between(from, to)
@@ -274,10 +274,10 @@ end
 @inline Base.:*(r::RotMatrix, spq::SPQuat) = r * Quat(spq)
 @inline Base.:*(spq1::SPQuat, spq2::SPQuat) = Quat(spq1) * Quat(spq2)
 
-@inline Base.inv(spq::SPQuat) = SPQuat(-spq.x, -spq.y, -spq.z)
+@inline inv(spq::SPQuat) = SPQuat(-spq.x, -spq.y, -spq.z)
 
-@inline Base.eye(::Type{SPQuat}) = SPQuat(0.0, 0.0, 0.0)
-@inline Base.eye(::Type{SPQuat{T}}) where {T} = SPQuat{T}(zero(T), zero(T), zero(T))
+@inline eye(::Type{SPQuat}) = SPQuat(0.0, 0.0, 0.0)
+@inline eye(::Type{SPQuat{T}}) where {T} = SPQuat{T}(zero(T), zero(T), zero(T))
 
 # rotation properties
 @inline rotation_angle(spq::SPQuat) = rotation_angle(Quat(spq))

--- a/src/util.jl
+++ b/src/util.jl
@@ -10,9 +10,9 @@ function perpendicular_vector(vec::SVector{3})
 
     # find indices of the two elements of vec with the largest absolute values:
     absvec = abs.(vec)
-    ind1 = indmax(absvec) # index of largest element
+    ind1 = argmax(absvec) # index of largest element
     @inbounds absvec2 = @SVector [ifelse(i == ind1, typemin(T), absvec[i]) for i = 1 : 3] # set largest element to typemin(T)
-    ind2 = indmax(absvec2) # index of second-largest element
+    ind2 = argmax(absvec2) # index of second-largest element
 
     # perp[ind1] = -vec[ind2], perp[ind2] = vec[ind1], set remaining element to zero:
     @inbounds perpind1 = -vec[ind2]

--- a/test/2d.jl
+++ b/test/2d.jl
@@ -112,19 +112,6 @@ using Rotations, StaticArrays, Compat.Test
             @test R * R ≈ T[0 -1; 1 0]
         end
     end
-
-    @testset "show" begin
-        io = IOBuffer()
-        r = rand(RotMatrix{2})
-        show(io, MIME("text/plain"), r)
-        str = String(take!(io))
-        @test startswith(str, "2×2 RotMatrix{Float64}:")
-
-        rxyz = RotXYZ(1.0, 2.0, 3.0)
-        show(io, MIME("text/plain"), rxyz)
-        str = String(take!(io))
-        @test startswith(str, "3×3 RotXYZ{Float64}(1.0, 2.0, 3.0):")
-    end
 end
 
 nothing

--- a/test/2d.jl
+++ b/test/2d.jl
@@ -1,4 +1,4 @@
-using Rotations, StaticArrays, Base.Test
+using Rotations, StaticArrays, Compat.Test
 
 @testset "2d Rotations" begin
 
@@ -38,8 +38,8 @@ using Rotations, StaticArrays, Base.Test
         for i = 1:repeats
             r = rand(R)
             @test isrotation(r)
-            @test inv(r) == r'
-            @test inv(r) == r.'
+            @test inv(r) == adjoint(r)
+            @test inv(r) == transpose(r)
             @test inv(r)*r ≈ I
             @test r*inv(r) ≈ I
         end
@@ -119,6 +119,11 @@ using Rotations, StaticArrays, Base.Test
         show(io, MIME("text/plain"), r)
         str = String(take!(io))
         @test startswith(str, "2×2 RotMatrix{Float64}:")
+
+        rxyz = RotXYZ(1.0, 2.0, 3.0)
+        show(io, MIME("text/plain"), rxyz)
+        str = String(take!(io))
+        @test startswith(str, "3×3 RotXYZ{Float64}(1.0, 2.0, 3.0):")
     end
 end
 

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -183,7 +183,7 @@ all_types = (RotMatrix{3}, Quat, SPQuat, AngleAxis, RodriguesVec,
     #########################################################################
     function nearest_orthonormal(not_orthonormal)
         u,s,v = svd(not_orthonormal)
-        return u * diagm([1, 1, sign(det(u * transpose(v)))]) * transpose(v)
+        return u * Diagonal([1, 1, sign(det(u * transpose(v)))]) * transpose(v)
     end
 
     @testset "DCM to Quat" begin
@@ -301,5 +301,18 @@ all_types = (RotMatrix{3}, Quat, SPQuat, AngleAxis, RodriguesVec,
     @testset "Testing RotMatrix conversion to Tuple" begin
         rot = eye(RotMatrix{3, Float64})
         @inferred Tuple(rot)
+    end
+
+    @testset "Testing show" begin
+        io = IOBuffer()
+        r = rand(RotMatrix{2})
+        show(io, MIME("text/plain"), r)
+        str = String(take!(io))
+        @test startswith(str, "2×2 RotMatrix{2,Float64,4}:")
+
+        rxyz = RotXYZ(1.0, 2.0, 3.0)
+        show(io, MIME("text/plain"), rxyz)
+        str = String(take!(io))
+        @test startswith(str, "3×3 RotXYZ{Float64}(1.0, 2.0, 3.0):")
     end
 end

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -108,8 +108,8 @@ all_types = (RotMatrix{3}, Quat, SPQuat, AngleAxis, RodriguesVec,
             srand(0)
             for i = 1:repeats
                 r = rand(R)
-                @test inv(r) == r'
-                @test inv(r) == r.'
+                @test inv(r) == adjoint(r)
+                @test inv(r) == transpose(r)
                 @test inv(r)*r ≈ I
                 @test r*inv(r) ≈ I
             end
@@ -183,7 +183,7 @@ all_types = (RotMatrix{3}, Quat, SPQuat, AngleAxis, RodriguesVec,
     #########################################################################
     function nearest_orthonormal(not_orthonormal)
         u,s,v = svd(not_orthonormal)
-        return u * diagm([1, 1, sign(det(u * v.'))]) * v.'
+        return u * diagm([1, 1, sign(det(u * transpose(v)))]) * transpose(v)
     end
 
     @testset "DCM to Quat" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,10 @@
-using Base.Test
+using Compat
+using Compat.Test
+using Compat.LinearAlgebra
 using Rotations
 using StaticArrays
+
+import Compat.Random: srand
 
 # Check that there are no ambiguities beyond those present in StaticArrays
 ramb = detect_ambiguities(Rotations, Base, Core)
@@ -14,4 +18,4 @@ include("2d.jl")
 include("rotation_tests.jl")
 include("derivative_tests.jl")
 
-include(joinpath("..", "perf", "runbenchmarks.jl"))
+include(joinpath(@__DIR__, "..", "perf", "runbenchmarks.jl"))


### PR DESCRIPTION
Passes tests on 0.6 and 0.7 locally.

I commented out the `showarray` method and associated test for now. The `showarray` functionality has changed quite a bit on master.

Benchmark results are a mixed bag, but nothing outrageous (and no allocations):
```
 Pair{Any,Any}("RotMatrix{3} * RotMatrix{3}", TrialJudgement(+5.88% => regression))
 Pair{Any,Any}("Rotations.SPQuat{Float64} -> Rotations.RodriguesVec{Float64}", TrialJudgement(-3.23% => invariant))          
 Pair{Any,Any}("Rotations.SPQuat{Float64} -> Rotations.AngleAxis{Float64}", TrialJudgement(+2.72% => invariant))             
 Pair{Any,Any}("Rotations.RodriguesVec{Float64} -> Rotations.Quat{Float64}", TrialJudgement(-1.10% => invariant))            
 Pair{Any,Any}("Rotations.Quat{Float64} -> Rotations.RodriguesVec{Float64}", TrialJudgement(-9.68% => improvement))          
 Pair{Any,Any}("Rotations.Quat{Float64} -> Rotations.AngleAxis{Float64}", TrialJudgement(+28.40% => regression))             
 Pair{Any,Any}("Rotations.AngleAxis{Float64} -> Rotations.SPQuat{Float64}", TrialJudgement(-4.46% => invariant))             
 Pair{Any,Any}("Rotations.SPQuat{Float64} -> Rotations.Quat{Float64}", TrialJudgement(+5.66% => regression))                 
 Pair{Any,Any}("Rotations.Quat{Float64} -> Rotations.SPQuat{Float64}", TrialJudgement(-21.57% => improvement))               
 Pair{Any,Any}("Rotations.RotMatrix{3,Float64,9} -> Rotations.Quat{Float64}", TrialJudgement(-1.27% => invariant))           
 Pair{Any,Any}("Rotations.RotMatrix{3,Float64,9} -> Rotations.AngleAxis{Float64}", TrialJudgement(+5.60% => regression))     
 Pair{Any,Any}("Rotations.AngleAxis{Float64} -> Rotations.RodriguesVec{Float64}", TrialJudgement(+6.45% => regression))      
 Pair{Any,Any}("Rotations.RodriguesVec{Float64} -> Rotations.AngleAxis{Float64}", TrialJudgement(+7.84% => regression))      
 Pair{Any,Any}("Rotations.RodriguesVec{Float64} -> Rotations.RotMatrix{3,Float64,9}", TrialJudgement(-22.18% => improvement))
 Pair{Any,Any}("Rotations.RodriguesVec{Float64} -> Rotations.SPQuat{Float64}", TrialJudgement(+12.41% => regression))        
 Pair{Any,Any}("Rotations.Quat{Float64} -> Rotations.RotMatrix{3,Float64,9}", TrialJudgement(+34.88% => regression))         
 Pair{Any,Any}("Rotations.AngleAxis{Float64} -> Rotations.RotMatrix{3,Float64,9}", TrialJudgement(+1.43% => invariant))      
 Pair{Any,Any}("Rotations.RotMatrix{3,Float64,9} -> Rotations.SPQuat{Float64}", TrialJudgement(-5.98% => improvement))       
 Pair{Any,Any}("Rotations.SPQuat{Float64} -> Rotations.RotMatrix{3,Float64,9}", TrialJudgement(+13.04% => regression))       
 Pair{Any,Any}("Rotations.AngleAxis{Float64} -> Rotations.Quat{Float64}", TrialJudgement(+1.59% => invariant))               
 Pair{Any,Any}("Rotations.RotMatrix{3,Float64,9} -> Rotations.RodriguesVec{Float64}", TrialJudgement(+32.09% => regression))
```

