### PR TITLE
Work around inference issues in perpendicular_vector on 0.6.3.

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -11,11 +11,13 @@ function perpendicular_vector(vec::SVector{3})
     # find indices of the two elements of vec with the largest absolute values:
     absvec = abs.(vec)
     ind1 = argmax(absvec) # index of largest element
-    @inbounds absvec2 = @SVector [ifelse(i == ind1, typemin(T), absvec[i]) for i = 1 : 3] # set largest element to typemin(T)
+    tmin = typemin(T)
+    @inbounds absvec2 = @SVector [ifelse(i == ind1, tmin, absvec[i]) for i = 1 : 3] # set largest element to typemin(T)
     ind2 = argmax(absvec2) # index of second-largest element
 
     # perp[ind1] = -vec[ind2], perp[ind2] = vec[ind1], set remaining element to zero:
     @inbounds perpind1 = -vec[ind2]
     @inbounds perpind2 = vec[ind1]
-    perp = @SVector [ifelse(i == ind1, perpind1, ifelse(i == ind2, perpind2, zero(T))) for i = 1 : 3]
+    tzero = zero(T)
+    perp = @SVector [ifelse(i == ind1, perpind1, ifelse(i == ind2, perpind2, tzero)) for i = 1 : 3]
 end

--- a/test/util_tests.jl
+++ b/test/util_tests.jl
@@ -1,10 +1,14 @@
 @testset "Util" begin
     @testset "Perpendicular vector" begin
         for i = 1 : 100
-            vec = rand(SVector{3, Float64})
+            vec = randn(SVector{3, Float64})
             perp = Rotations.perpendicular_vector(vec)
             @test norm(perp) >= maximum(abs.(vec))
             @test isapprox(dot(vec, perp), 0.; atol = 1e-10)
+        end
+        let vec = randn(SVector{3, Float64})
+            allocs = @allocated Rotations.perpendicular_vector(vec)
+            @test allocs == 0
         end
     end
 end


### PR DESCRIPTION
Actually not 100% sure this appeared in 0.6.3, but I think so. Anyway, this fixes the problem and adds a test to make sure it doesn't reappear.