### PR TITLE
Adapt to `eye` change

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ or [AffineTransforms.jl](https://github.com/timholy/AffineTransforms.jl) package
 using Rotations, StaticArrays
 
 # create the null rotation (identity matrix)
-id = eye(RotMatrix{3, Float64})
+id = one(RotMatrix{3, Float64})
 
 # create a random rotation matrix (uniformly distributed over all 3D rotations)
 r = rand(RotMatrix{3}) # uses Float64 by default

--- a/src/Rotations.jl
+++ b/src/Rotations.jl
@@ -7,7 +7,7 @@ using Compat
 using Compat.LinearAlgebra
 using StaticArrays
 
-import Base: convert, eltype, size, length, getindex, *, Tuple
+import Base: convert, eltype, size, length, getindex, *, Tuple, one
 import Compat.LinearAlgebra: inv, eye
 
 if VERSION >= v"0.7.0-beta.85"

--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -119,8 +119,16 @@ end
 
 
 # define null rotations for convenience
-@inline eye(::Type{AngleAxis}) = AngleAxis(0.0, 1.0, 0.0, 0.0)
-@inline eye(::Type{AngleAxis{T}}) where {T} = AngleAxis{T}(zero(T), one(T), zero(T), zero(T))
+@inline Base.one(::Type{AngleAxis}) = AngleAxis(0.0, 1.0, 0.0, 0.0)
+@inline Base.one(::Type{AngleAxis{T}}) where {T} = AngleAxis{T}(zero(T), one(T), zero(T), zero(T))
+
+if VERSION < v"0.7-"
+    eye(::Type{AngleAxis}) = one(AngleAxis)
+    eye(::Type{AngleAxis{T}}) where {T} = one(AngleAxis{T})
+elseif isdefined(LinearAlgebra, :eye)
+    Base.@deprecate eye(::Type{AngleAxis}) one(AngleAxis)
+    Base.@deprecate eye(::Type{AngleAxis{T}}) where {T} one(AngleAxis{T})
+end
 
 # accessors
 @inline rotation_angle(aa::AngleAxis) = aa.theta #  - floor((aa.theta+pi) / (2*pi)) * 2*pi
@@ -223,5 +231,13 @@ function rotation_axis(rv::RodriguesVec)     # what should this return for theta
 end
 
 # define null rotations for convenience
-@inline eye(::Type{RodriguesVec}) = RodriguesVec(0.0, 0.0, 0.0)
-@inline eye(::Type{RodriguesVec{T}}) where {T} = RodriguesVec{T}(zero(T), zero(T), zero(T))
+@inline Base.one(::Type{RodriguesVec}) = RodriguesVec(0.0, 0.0, 0.0)
+@inline Base.one(::Type{RodriguesVec{T}}) where {T} = RodriguesVec{T}(zero(T), zero(T), zero(T))
+
+if VERSION < v"0.7-"
+    eye(::Type{RodriguesVec}) = one(RodriguesVec)
+    eye(::Type{RodriguesVec{T}}) where {T} = one(RodriguesVec{T})
+elseif isdefined(LinearAlgebra, :eye)
+    Base.@deprecate eye(::Type{RodriguesVec}) one(RodriguesVec)
+    Base.@deprecate eye(::Type{RodriguesVec{T}}) where {T} one(RodriguesVec{T})
+end

--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -141,12 +141,12 @@ function isrotation(r::AbstractMatrix{T}, tol::Real = 1000 * eps(eltype(T))) whe
         # Transpose is overloaded for many of our types, so we do it explicitly:
         r_trans = @SMatrix [conj(r[1,1])  conj(r[2,1]);
                             conj(r[1,2])  conj(r[2,2])]
-        d = Compat.norm((r * r_trans) - eye(SMatrix{2,2}))
+        d = Compat.norm((r * r_trans) - one(SMatrix{2,2}))
     elseif size(r) == (3,3)
         r_trans = @SMatrix [conj(r[1,1])  conj(r[2,1])  conj(r[3,1]);
                             conj(r[1,2])  conj(r[2,2])  conj(r[2,3]);
                             conj(r[1,3])  conj(r[2,3])  conj(r[3,3])]
-        d = Compat.norm((r * r_trans) - eye(SMatrix{3,3}))
+        d = Compat.norm((r * r_trans) - one(SMatrix{3,3}))
     else
         return false
     end

--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -104,9 +104,13 @@ Base.@propagate_inbounds Base.getindex(r::RotMatrix, i::Int) = r.mat[i]
 # A rotation is more-or-less defined as being an orthogonal (or unitary) matrix
 inv(r::RotMatrix) = RotMatrix(r.mat')
 
-# A useful constructor for identity rotation (eye is already provided by StaticArrays, but needs an eltype)
-@inline eye(::Type{RotMatrix{N}}) where {N} = RotMatrix((eye(SMatrix{N,N,Float64})))
-@inline eye(::Type{RotMatrix{N,T}}) where {N,T} = RotMatrix((eye(SMatrix{N,N,T})))
+if VERSION < v"0.7-"
+    eye(::Type{RotMatrix{N}}) where {N} = one(RotMatrix{N})
+    eye(::Type{RotMatrix{N,T}}) where {N,T} = one(RotMatrix{N,T})
+elseif isdefined(LinearAlgebra, :eye)
+    Base.@deprecate eye(::Type{RotMatrix{N}}) where {N} one(RotMatrix{N})
+    Base.@deprecate eye(::Type{RotMatrix{N,T}}) where {N,T} one(RotMatrix{N,T})
+end
 
 # By default, composition of rotations will go through RotMatrix, unless overridden
 @inline *(r1::Rotation, r2::Rotation) = RotMatrix(r1) * RotMatrix(r2)

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -189,7 +189,7 @@ function jacobian(q::Quat, X::AbstractVector)
     # derivatives ignoring the scaling
     q_im = SVector(2*q.x, 2*q.y, 2*q.z)
     dRdQr  = SVector{3}(2 * q.w * X + cross(q_im, X))
-    dRdQim = -X * q_im' + dot(X, q_im) * eye(SMatrix{3,3,T}) + q_im * X' - 2*q.w * d_cross(X)
+    dRdQim = -X * q_im' + dot(X, q_im) * one(SMatrix{3,3,T}) + q_im * X' - 2*q.w * d_cross(X)
 
     dRdQs = hcat(dRdQr, dRdQim)
 
@@ -263,7 +263,7 @@ function hessian(::Type{Quaternion},  X::SpQuat)
 
     # dC/dxx terms (middle two terms cancel)
     T = eltype(A)
-    dCdxx = eye(Mat{3,3,T}) * (-2 * (A + B))
+    dCdxx = one(Mat{3,3,T}) * (-2 * (A + B))
 
     # dC/dxy terms (dB/dxdy and dA/dxdy) are zero
     # put it all together
@@ -451,7 +451,7 @@ function hessian(q::Quaternion, X::AbstractVector)
     #
     q_im = SVector(2*q.x, 2*q.y, 2*q.z)
     dRdQr  = 2 * q.w * X + cross(q_im, X)
-    dRdQim = -X * q_im' + dot(X, q_im) * eye(Mat{3,3,T}) + q_im * X' - 2* q.w * d_cross(X)
+    dRdQim = -X * q_im' + dot(X, q_im) * one(Mat{3,3,T}) + q_im * X' - 2* q.w * d_cross(X)
 
     #
     # second derivative ignoring the scaling
@@ -485,7 +485,7 @@ function hessian(q::Quaternion, X::AbstractVector)
     dSdQt = dSdQ'
 
     s2 = s*s
-    d2SdQ = (eye(Mat{4,4,T}) * s -  SVector(q) * dSdQ') / (s2)
+    d2SdQ = (one(Mat{4,4,T}) * s -  SVector(q) * dSdQ') / (s2)
 
     # and combine them
     dSdQ_2 = 2 * dSdQ * dSdQt

--- a/src/euler_types.jl
+++ b/src/euler_types.jl
@@ -31,8 +31,19 @@ for axis in [:X, :Y, :Z]
         @inline inv(r::$RotType) = $RotType(-r.theta)
 
         # define null rotations for convenience
-        @inline eye(::Type{$RotType}) = $RotType(0.0)
-        @inline eye(::Type{$RotType{T}}) where {T} = $RotType{T}(zero(T))
+        @inline one(::Type{$RotType}) = $RotType(0.0)
+        @inline one(::Type{$RotType{T}}) where {T} = $RotType{T}(zero(T))
+    end
+    if VERSION < v"0.7-"
+        @eval begin
+            eye(::Type{$RotType}) = one($RotType)
+            eye(::Type{$RotType{T}}) where {T} = one($RotType{T})
+        end
+    elseif isdefined(LinearAlgebra, :eye)
+        @eval begin
+            Base.@deprecate eye(::Type{$RotType}) one($RotType)
+            Base.@deprecate eye(::Type{$RotType{T}}) where {T} one($RotType{T})
+        end
     end
 end
 
@@ -241,8 +252,19 @@ for axis1 in [:X, :Y, :Z]
             @inline inv(r::$RotType) = $InvRotType(-r.theta2, -r.theta1)
 
             # define null rotations for convenience
-            @inline eye(::Type{$RotType}) = $RotType(0.0, 0.0)
-            @inline eye(::Type{$RotType{T}}) where {T} = $RotType{T}(zero(T), zero(T))
+            @inline one(::Type{$RotType}) = $RotType(0.0, 0.0)
+            @inline one(::Type{$RotType{T}}) where {T} = $RotType{T}(zero(T), zero(T))
+        end
+        if VERSION < v"0.7-"
+            @eval begin
+                eye(::Type{$RotType}) = one($RotType)
+                eye(::Type{$RotType{T}}) where {T} = one($RotType{T})
+            end
+        elseif isdefined(LinearAlgebra, :eye)
+            @eval begin
+                Base.@deprecate eye(::Type{$RotType}) one($RotType)
+                Base.@deprecate eye(::Type{$RotType{T}}) where {T} one($RotType{T})
+            end
         end
     end
 end
@@ -553,8 +575,19 @@ for axis1 in [:X, :Y, :Z]
                 @inline inv(r::$RotType) = $InvRotType(-r.theta3, -r.theta2, -r.theta1)
 
                 # define null rotations for convenience
-                @inline eye(::Type{$RotType}) = $RotType(0.0, 0.0, 0.0)
-                @inline eye(::Type{$RotType{T}}) where {T} = $RotType{T}(zero(T), zero(T), zero(T))
+                @inline one(::Type{$RotType}) = $RotType(0.0, 0.0, 0.0)
+                @inline one(::Type{$RotType{T}}) where {T} = $RotType{T}(zero(T), zero(T), zero(T))
+            end
+            if VERSION < v"0.7-"
+                @eval begin
+                    eye(::Type{$RotType}) = one($RotType)
+                    eye(::Type{$RotType{T}}) where {T} = one($RotType{T})
+                end
+            else
+                @eval begin
+                    Base.@deprecate eye(::Type{$RotType}) one($RotType)
+                    Base.@deprecate eye(::Type{$RotType{T}}) where {T} one($RotType{T})
+                end
             end
         end
     end

--- a/src/quaternion_types.jl
+++ b/src/quaternion_types.jl
@@ -192,8 +192,16 @@ function inv(q::Quat)
     Quat(q.w, -q.x, -q.y, -q.z)
 end
 
-@inline eye(::Type{Quat}) = Quat(1.0, 0.0, 0.0, 0.0)
-@inline eye(::Type{Quat{T}}) where {T} = Quat{T}(one(T), zero(T), zero(T), zero(T))
+@inline one(::Type{Quat}) = Quat(1.0, 0.0, 0.0, 0.0)
+@inline one(::Type{Quat{T}}) where {T} = Quat{T}(one(T), zero(T), zero(T), zero(T))
+
+if VERSION < v"0.7-"
+    eye(::Type{Quat}) = one(Quat)
+    eye(::Type{Quat{T}}) where {T} = one(Quat{T})
+elseif isdefined(LinearAlgebra, :eye)
+    Base.@deprecate eye(::Type{Quat}) one(Quat)
+    Base.@deprecate eye(::Type{Quat{T}}) where {T} one(Quat{T})
+end
 
 """
     rotation_between(from, to)
@@ -276,8 +284,16 @@ end
 
 @inline inv(spq::SPQuat) = SPQuat(-spq.x, -spq.y, -spq.z)
 
-@inline eye(::Type{SPQuat}) = SPQuat(0.0, 0.0, 0.0)
-@inline eye(::Type{SPQuat{T}}) where {T} = SPQuat{T}(zero(T), zero(T), zero(T))
+@inline one(::Type{SPQuat}) = SPQuat(0.0, 0.0, 0.0)
+@inline one(::Type{SPQuat{T}}) where {T} = SPQuat{T}(zero(T), zero(T), zero(T))
+
+if VERSION < v"0.7-"
+    eye(::Type{SPQuat}) = one(SPQuat)
+    eye(::Type{SPQuat{T}}) where {T} = one(SPQuat{T})
+elseif isdefined(LinearAlgebra, :eye)
+    Base.@deprecate eye(::Type{SPQuat}) one(SPQuat)
+    Base.@deprecate eye(::Type{SPQuat{T}}) where {T} one(SPQuat{T})
+end
 
 # rotation properties
 @inline rotation_angle(spq::SPQuat) = rotation_angle(Quat(spq))

--- a/test/2d.jl
+++ b/test/2d.jl
@@ -7,7 +7,7 @@ using Rotations, StaticArrays, Compat.Test
     #################################
 
     @testset "Core" begin
-        r = eye(RotMatrix{2,Float32})
+        r = one(RotMatrix{2,Float32})
         @test RotMatrix((1,0,0,1)) == RotMatrix(@SMatrix [1 0; 0 1])
         @test_throws ErrorException RotMatrix((1,0,0,1,0))
     end
@@ -17,13 +17,13 @@ using Rotations, StaticArrays, Compat.Test
     ###############################
 
     @testset "Identity rotation checks" begin
-        I = eye(SMatrix{2,2,Float64})
-        I32 = eye(SMatrix{2,2,Float32})
+        I = one(SMatrix{2,2,Float64})
+        I32 = one(SMatrix{2,2,Float32})
         R = RotMatrix{2}
         @test @inferred(size(R)) == (2,2)
         @test @inferred(size(R{Float32})) == (2,2)
-        @test eye(R)::R == I
-        @test eye(R{Float32})::R{Float32} == I32
+        @test one(R)::R == I
+        @test one(R{Float32})::R{Float32} == I32
     end
 
     ################################
@@ -33,7 +33,7 @@ using Rotations, StaticArrays, Compat.Test
     @testset "Testing inverse()" begin
         repeats = 100
         R = RotMatrix{2,Float64}
-        I = eye(R)
+        I = one(R)
         srand(0)
         for i = 1:repeats
             r = rand(R)

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -89,11 +89,11 @@ all_types = (RotMatrix{3}, Quat, SPQuat, AngleAxis, RodriguesVec,
     ###############################
 
     @testset "Identity rotation checks" begin
-        I = eye(SMatrix{3,3,Float64})
-        I32 = eye(SMatrix{3,3,Float32})
+        I = one(SMatrix{3,3,Float64})
+        I32 = one(SMatrix{3,3,Float32})
         @testset "$(R)" for R in all_types
-            @test eye(R)::R == I
-            @test eye(R{Float32})::R{Float32} == I32
+            @test one(R)::R == I
+            @test one(R{Float32})::R{Float32} == I32
         end
     end
 
@@ -103,7 +103,7 @@ all_types = (RotMatrix{3}, Quat, SPQuat, AngleAxis, RodriguesVec,
 
     @testset "Testing inverse()" begin
         repeats = 100
-        I = eye(RotMatrix{3,Float64})
+        I = one(RotMatrix{3,Float64})
         @testset "$(R)" for R in all_types
             srand(0)
             for i = 1:repeats
@@ -280,8 +280,8 @@ all_types = (RotMatrix{3}, Quat, SPQuat, AngleAxis, RodriguesVec,
     end
 
     @testset "Testing type aliases" begin
-        @test eye(RotMatrix{2, Float64}) isa RotMatrix2{Float64}
-        @test eye(RotMatrix{3, Float64}) isa RotMatrix3{Float64}
+        @test one(RotMatrix{2, Float64}) isa RotMatrix2{Float64}
+        @test one(RotMatrix{3, Float64}) isa RotMatrix3{Float64}
     end
 
     @testset "Testing normalization" begin
@@ -299,7 +299,7 @@ all_types = (RotMatrix{3}, Quat, SPQuat, AngleAxis, RodriguesVec,
     end
 
     @testset "Testing RotMatrix conversion to Tuple" begin
-        rot = eye(RotMatrix{3, Float64})
+        rot = one(RotMatrix{3, Float64})
         @inferred Tuple(rot)
     end
 


### PR DESCRIPTION
First commit adds `@deprecate`s, second commit fixes deprecations. I ran tests after the first commit to ensure that the depwarns are working correctly.