### PR TITLE
Improve benchmark suite, fix Euler -> RotMatrix conversion performance

### DIFF
--- a/perf/runbenchmarks.jl
+++ b/perf/runbenchmarks.jl
@@ -1,3 +1,4 @@
+using Compat
 using Rotations
 using BenchmarkTools
 import Base.Iterators: product
@@ -8,25 +9,46 @@ const T = Float64
 const suite = BenchmarkGroup()
 srand(1)
 
-suite["conversions"] = BenchmarkGroup()
-rotationtypes = (RotMatrix3{T}, Quat{T}, SPQuat{T}, AngleAxis{T}, RodriguesVec{T})
+noneuler = suite["Non-Euler conversions"] = BenchmarkGroup()
+rotationtypes = [RotMatrix3{T}, Quat{T}, SPQuat{T}, AngleAxis{T}, RodriguesVec{T}]
 for (from, to) in product(rotationtypes, rotationtypes)
     if from != to
+        # TODO: drop the `Rotations.` part on 0.7. This is to maintain the same names between 0.6 and 0.7
         name = if VERSION < v"0.7.0-"
             "$(string(from)) -> $(string(to))"
         else
             "Rotations.$(string(from)) -> Rotations.$(string(to))"
         end
         # use eval here because of https://github.com/JuliaCI/BenchmarkTools.jl/issues/50#issuecomment-318673288
-        suite["conversions"][name] = eval(:(@benchmarkable convert($to, rot) setup = rot = rand($from)))
+        noneuler[name] = eval(:(@benchmarkable convert($to, rot) setup = rot = rand($from)))
     end
 end
 
-suite["composition"] = BenchmarkGroup()
-suite["composition"]["RotMatrix{3} * RotMatrix{3}"] = @benchmarkable(
-    r1 * r2,
-    setup = (r1 = rand(RotMatrix3{T}); r2 = rand(RotMatrix3{T}))
-)
+euler = suite["Euler conversions"] = BenchmarkGroup()
+eulertypes = [
+    RotX{T}, RotY{T}, RotZ{T},
+    RotXY{T}, RotYX{T}, RotZX{T}, RotXZ{T}, RotYZ{T}, RotZY{T},
+    RotXYX{T}, RotYXY{T}, RotZXZ{T}, RotXZX{T}, RotYZY{T}, RotZYZ{T},
+    RotXYZ{T}, RotYXZ{T}, RotZXY{T}, RotXZY{T}, RotYZX{T}, RotZYX{T}]
+for from in eulertypes
+    to = RotMatrix3{T}
+    # TODO: drop the `Rotations.` part on 0.7. This is to maintain the same names between 0.6 and 0.7
+    name = if VERSION < v"0.7.0-"
+        "$(string(from)) -> $(string(to))"
+    else
+        "Rotations.$(string(from)) -> Rotations.$(string(to))"
+    end
+    # use eval here because of https://github.com/JuliaCI/BenchmarkTools.jl/issues/50#issuecomment-318673288
+    euler[name] = eval(:(@benchmarkable convert($to, rot) setup = rot = rand($from)))
+end
+
+
+composition = suite["Composition"] = BenchmarkGroup()
+# use eval here because of https://github.com/JuliaCI/BenchmarkTools.jl/issues/50#issuecomment-318673288
+composition["RotMatrix{3} * RotMatrix{3}"] = eval(:(@benchmarkable r1 * r2 setup = begin
+    r1 = rand(RotMatrix3{T})
+    r2 = rand(RotMatrix3{T})
+end))
 
 paramspath = joinpath(@__DIR__, "benchmarkparams.json")
 if isfile(paramspath)
@@ -37,12 +59,15 @@ else
 end
 
 results = run(suite, verbose=true)
+println()
 for (groupname, groupresults) in results
     println("Group: $groupname")
-    for result in groupresults
-        println("$(first(result)):")
-        display(minimum(last(result)))
-        println()
+    max_name_length = maximum(length, keys(groupresults))
+    for (name, trial) in groupresults
+        if minimum(trial).allocs != 0
+            Compat.@warn("$name  allocates!")
+        end
+        println(rpad(name, max_name_length), " ", BenchmarkTools.prettytime(minimum(trial).time))
     end
     println()
 end

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -37,7 +37,7 @@ function jacobian(::Type{RotMatrix},  q::Quat)
 
     # get R(q)
     # R = q[:] # FIXME: broken with StaticArrays 0.4.0 due to https://github.com/JuliaArrays/StaticArrays.jl/issues/128
-    R = SVector(convert(Tuple, q))
+    R = SVector(Tuple(q))
 
     # solve d(s*R)/dQ (because its easy)
     dsRdQ = @SMatrix [ 2*q.w   2*q.x   -2*q.y   -2*q.z ;

--- a/src/euler_types.jl
+++ b/src/euler_types.jl
@@ -75,7 +75,7 @@ RotX
     end
 end
 
-@inline function Base.convert(::Type{Tuple}, r::RotX{T}) where T
+@inline function Tuple(r::RotX{T}) where T
     T2 = Base.promote_op(sin, T)
     (one(T2),   zero(T2),     zero(T2),   # transposed representation
      zero(T2),  cos(r.theta), sin(r.theta),
@@ -128,7 +128,7 @@ RotY
     end
 end
 
-@inline function Base.convert(::Type{Tuple}, r::RotY{T}) where T
+@inline function Tuple(r::RotY{T}) where T
     T2 = Base.promote_op(sin, T)
     (cos(r.theta), zero(T2), -sin(r.theta),   # transposed representation
      zero(T2),     one(T2),   zero(T2),
@@ -177,7 +177,7 @@ RotZ
     end
 end
 
-@inline function Base.convert(::Type{Tuple}, r::RotZ{T}) where T
+@inline function Tuple(r::RotZ{T}) where T
     T2 = Base.promote_op(sin, T)
     ( cos(r.theta), sin(r.theta), zero(T2),   # transposed representation
      -sin(r.theta), cos(r.theta), zero(T2),
@@ -226,7 +226,7 @@ for axis1 in [:X, :Y, :Z]
             @inline convert(::Type{R}, r::R) where {R<:$RotType} = r
 
             @inline function Base.getindex(r::$RotType{T}, i::Int) where T
-                convert(Tuple, r)[i] # Slow...
+                Tuple(r)[i] # Slow...
             end
 
             @inline (::Type{R})(t::NTuple{9}) where {R<:$RotType} = error("Cannot construct a two-axis rotation from a matrix")
@@ -269,7 +269,7 @@ followed by a rotation by `theta_x` about the X axis.
 """
 RotXY
 
-@inline function Base.convert(::Type{Tuple}, r::RotXY{T}) where T
+@inline function Tuple(r::RotXY{T}) where T
     sinθ₁ = sin(r.theta1)
     cosθ₁ = cos(r.theta1)
     sinθ₂ = sin(r.theta2)
@@ -310,7 +310,7 @@ followed by a rotation by `theta_y` about the Y axis.
 """
 RotYX
 
-@inline function Base.convert(::Type{Tuple}, r::RotYX{T}) where T
+@inline function Tuple(r::RotYX{T}) where T
     sinθ₁ = sin(r.theta1)
     cosθ₁ = cos(r.theta1)
     sinθ₂ = sin(r.theta2)
@@ -351,7 +351,7 @@ followed by a rotation by `theta_x` about the X axis.
 """
 RotXZ
 
-@inline function Base.convert(::Type{Tuple}, r::RotXZ{T}) where T
+@inline function Tuple(r::RotXZ{T}) where T
     sinθ₁ = sin(r.theta1)
     cosθ₁ = cos(r.theta1)
     sinθ₂ = sin(r.theta2)
@@ -392,7 +392,7 @@ followed by a rotation by `theta_z` about the Z axis.
 """
 RotZX
 
-@inline function Base.convert(::Type{Tuple}, r::RotZX{T}) where T
+@inline function Tuple(r::RotZX{T}) where T
     sinθ₁ = sin(r.theta1)
     cosθ₁ = cos(r.theta1)
     sinθ₂ = sin(r.theta2)
@@ -433,7 +433,7 @@ followed by a rotation by `theta_z` about the Z axis.
 """
 RotZY
 
-@inline function Base.convert(::Type{Tuple}, r::RotZY{T}) where T
+@inline function Tuple(r::RotZY{T}) where T
     sinθ₁ = sin(r.theta1)
     cosθ₁ = cos(r.theta1)
     sinθ₂ = sin(r.theta2)
@@ -474,7 +474,7 @@ followed by a rotation by `theta_y` about the Y axis.
 """
 RotYZ
 
-@inline function Base.convert(::Type{Tuple}, r::RotYZ{T}) where T
+@inline function Tuple(r::RotYZ{T}) where T
     sinθ₁ = sin(r.theta1)
     cosθ₁ = cos(r.theta1)
     sinθ₂ = sin(r.theta2)
@@ -539,7 +539,7 @@ for axis1 in [:X, :Y, :Z]
                 @inline convert(::Type{R}, r::R) where {R<:$RotType} = r
 
                 @inline function Base.getindex(r::$RotType{T}, i::Int) where T
-                    convert(Tuple, r)[i] # Slow...
+                    Tuple(r)[i] # Slow...
                 end
 
                 # Composing single-axis rotations with two-axis rotations:
@@ -590,7 +590,7 @@ RotXYX
         atan(- R[2, 3]*ct1 - R[3, 3]*st1, R[2, 2]*ct1 + R[3, 2]*st1))
 end
 
-@inline function Base.convert(::Type{Tuple}, r::RotXYX{T}) where T
+@inline function Tuple(r::RotXYX{T}) where T
     sinθ₁ = sin(r.theta1)
     cosθ₁ = cos(r.theta1)
     sinθ₂ = sin(r.theta2)
@@ -647,7 +647,7 @@ RotXZX
         atan(R[3, 2]*ct1 - R[2, 2]*st1, R[3, 3]*ct1 - R[2, 3]*st1))
 end
 
-@inline function Base.convert(::Type{Tuple}, r::RotXZX{T}) where T
+@inline function Tuple(r::RotXZX{T}) where T
     sinθ₁ = sin(r.theta1)
     cosθ₁ = cos(r.theta1)
     sinθ₂ = sin(r.theta2)
@@ -704,7 +704,7 @@ RotYXY
         atan(R[1, 3]*ct1 - R[3, 3]*st1, R[1, 1]*ct1 - R[3, 1]*st1))
 end
 
-@inline function Base.convert(::Type{Tuple}, r::RotYXY{T}) where T
+@inline function Tuple(r::RotYXY{T}) where T
     sinθ₁ = sin(r.theta1)
     cosθ₁ = cos(r.theta1)
     sinθ₂ = sin(r.theta2)
@@ -761,7 +761,7 @@ RotYZY
         atan(- R[3, 1]*ct1 - R[1, 1]*st1, R[3, 3]*ct1 + R[1, 3]*st1))
 end
 
-@inline function Base.convert(::Type{Tuple}, r::RotYZY{T}) where T
+@inline function Tuple(r::RotYZY{T}) where T
     sinθ₁ = sin(r.theta1)
     cosθ₁ = cos(r.theta1)
     sinθ₂ = sin(r.theta2)
@@ -818,7 +818,7 @@ RotZXZ
         atan(- R[1, 2]*ct1 - R[2, 2]*st1, R[1, 1]*ct1 + R[2, 1]*st1))
 end
 
-@inline function Base.convert(::Type{Tuple}, r::RotZXZ{T}) where T
+@inline function Tuple(r::RotZXZ{T}) where T
     sinθ₁ = sin(r.theta1)
     cosθ₁ = cos(r.theta1)
     sinθ₂ = sin(r.theta2)
@@ -875,7 +875,7 @@ RotZYZ
         atan(R[2, 1]*ct1 - R[1, 1]*st1, R[2, 2]*ct1 - R[1, 2]*st1))
 end
 
-@inline function Base.convert(::Type{Tuple}, r::RotZYZ{T}) where T
+@inline function Tuple(r::RotZYZ{T}) where T
     sinθ₁ = sin(r.theta1)
     cosθ₁ = cos(r.theta1)
     sinθ₂ = sin(r.theta2)
@@ -942,7 +942,7 @@ RotXYZ
         atan(R[2, 1]*ct1 + R[3, 1]*st1, R[2, 2]*ct1 + R[3, 2]*st1))
 end
 
-@inline function Base.convert(::Type{Tuple}, r::RotXYZ{T}) where T
+@inline function Tuple(r::RotXYZ{T}) where T
     sinθ₁ = sin(r.theta1)
     cosθ₁ = cos(r.theta1)
     sinθ₂ = sin(r.theta2)
@@ -1006,7 +1006,7 @@ RotZYX
         atan(R[1, 3]*st1 - R[2, 3]*ct1, R[2, 2]*ct1 - R[1, 2]*st1))
 end
 
-@inline function Base.convert(::Type{Tuple}, r::RotZYX{T}) where T
+@inline function Tuple(r::RotZYX{T}) where T
     sinθ₁ = sin(r.theta1)
     cosθ₁ = cos(r.theta1)
     sinθ₂ = sin(r.theta2)
@@ -1070,7 +1070,7 @@ RotXZY
         atan(R[2, 1]*st1 - R[3, 1]*ct1, R[3, 3]*ct1 - R[2, 3]*st1))
 end
 
-@inline function Base.convert(::Type{Tuple}, r::RotXZY{T}) where T
+@inline function Tuple(r::RotXZY{T}) where T
     sinθ₁ = sin(r.theta1)
     cosθ₁ = cos(r.theta1)
     sinθ₂ = sin(r.theta2)
@@ -1134,7 +1134,7 @@ RotYZX
         atan(R[3, 2]*ct1 + R[1, 2]*st1, R[3, 3]*ct1 + R[1, 3]*st1))
 end
 
-@inline function Base.convert(::Type{Tuple}, r::RotYZX{T}) where T
+@inline function Tuple(r::RotYZX{T}) where T
     sinθ₁ = sin(r.theta1)
     cosθ₁ = cos(r.theta1)
     sinθ₂ = sin(r.theta2)
@@ -1198,7 +1198,7 @@ RotYXZ
         atan(R[3, 2]*st1 - R[1, 2]*ct1, R[1, 1]*ct1 - R[3, 1]*st1))
 end
 
-@inline function Base.convert(::Type{Tuple}, r::RotYXZ{T}) where T
+@inline function Tuple(r::RotYXZ{T}) where T
     sinθ₁ = sin(r.theta1)
     cosθ₁ = cos(r.theta1)
     sinθ₂ = sin(r.theta2)
@@ -1262,7 +1262,7 @@ RotZXY
         atan(R[1, 3]*ct1 + R[2, 3]*st1, R[1, 1]*ct1 + R[2, 1]*st1))
 end
 
-@inline function Base.convert(::Type{Tuple}, r::RotZXY{T}) where T
+@inline function Tuple(r::RotZXY{T}) where T
     sinθ₁ = sin(r.theta1)
     cosθ₁ = cos(r.theta1)
     sinθ₂ = sin(r.theta2)


### PR DESCRIPTION
In response to https://github.com/FugroRoames/Rotations.jl/pull/63#pullrequestreview-134509470, I added some benchmarks for Euler types -> RotMatrix (first commit), and was surprised to find that they allocate and are very slow. The second commit fixes that. I'm going to rebase tk/sincos on top of this.