### PR TITLE
Require Compat 0.70 for norm.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.6
 StaticArrays 0.6.5
-Compat 0.69 # for atan(y, x)
+Compat 0.70 # for norm


### PR DESCRIPTION
Ref https://github.com/FugroRoames/Rotations.jl/pull/61#issuecomment-402497086.