### PR TITLE
Fix inconsistent `Rotmatrix` issue

### DIFF
--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -97,7 +97,7 @@ end
 Base.@propagate_inbounds Base.getindex(r::RotMatrix, i::Int) = r.mat[i]
 @inline Base.Tuple(r::RotMatrix) = Tuple(r.mat)
 
-@inline RotMatrix(θ::Real) = RotMatrix{2}(θ)
+@inline RotMatrix(θ::Real) = RotMatrix{2}(mod(θ,2pi))
 @inline function (::Type{RotMatrix{2}})(θ::Real)
     s, c = sincos(θ)
     RotMatrix(@SMatrix [c -s; s c])


### PR DESCRIPTION
Original:
```julia
julia> RotMatrix(pi) == RotMatrix(-pi)
false
julia> RotMatrix(pi) ≈ RotMatrix(-pi)
true
julia> RotMatrix(0) == RotMatrix(2pi)
false
julia> RotMatrix(0) ≈ RotMatrix(2pi)
true
```

Update:
```julia
julia> RotMatrix(pi) == RotMatrix(-pi)
true
julia> RotMatrix(0) == RotMatrix(2pi)
true
```

By doing this, there's about 1 ns additional time usage.