### PR TITLE
Simplify CI scripts.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,22 +7,14 @@ julia:
   - 0.7
   - 1.0
   - nightly
-addons:
-  apt:
-    packages:
-    - hdf5-tools # work around HDF5 install issue on Trusty, see https://discourse.julialang.org/t/hdf5-fails-on-travis-ci-with-trusty-works-with-precise/4961
 notifications:
   email: false
 matrix:
   allow_failures:
     - julia: nightly
-#     - os: osx
-# uncomment the following lines to override the default test script
-#script:
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("Rotations"); Pkg.test("Rotations"; coverage=true)'
+branches:
+  only:
+    - master
+    - /^v[0-9]+\.[0-9]+\.[0-9]+$/ # version tags
 after_success:
-#    - if [ $TRAVIS_JULIA_VERSION = "release" ] && [ $TRAVIS_OS_NAME = "linux" ]; then
-    - if [ $TRAVIS_OS_NAME = "linux" ]; then
-         julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
-      fi
+  - julia --project -e 'import Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   matrix:
   - julia_version: 0.7
   - julia_version: 1
-  - julia_version: latest
+  - julia_version: nightly
 
 platform:
   - x86 # 32-bit
@@ -10,7 +10,7 @@ platform:
 
 matrix:
    allow_failures:
-   - julia_version: latest
+   - julia_version: nightly
 
 branches:
   only:


### PR DESCRIPTION
* hdf5 (previously used for BenchmarkTools package) no longer needed
* commented out lines to replace default test script wouldn't work anyway
* logic for Julia 0.5 no longer needed
* https://github.com/JuliaCI/Appveyor.jl now recommends using `nightly` instead of `latest` (both still work though, mostly just for consistency with Travis)
* stop building upon pushes to branches other than master or version tags