### PR TITLE
Stop enforcing that quat scalar component is nonnegative

### DIFF
--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -79,11 +79,11 @@ end
 end
 
 @inline function Base.convert(::Type{AA}, q::Quat) where AA <: AngleAxis
-    # TODO: consider how to deal with derivative near theta = 0
-    qs = sign(q.w)
-    s = sqrt(q.x*q.x + q.y*q.y + q.z*q.z)
-    theta =  2 * atan(s, qs * q.w)
-    return s > 0 ? AA(theta, qs * q.x / s, qs * q.y / s, qs * q.z / s, false) : AA(theta, one(theta), zero(theta), zero(theta), false)
+    s2 = q.x * q.x + q.y * q.y + q.z * q.z
+    cos_t2 = sqrt(s2)
+    theta = 2 * atan(cos_t2 / abs(q.w))
+    sc = ifelse(cos_t2 > 0, promote(copysign(1 / cos_t2, q.w), 2)...) # N.B. the 2 "should" match the derivitive as cos_t2 -> 0
+    return AA(theta, sc * q.x, sc * q.y, sc * q.z)
 end
 
 # Using Rodrigues formula on an AngleAxis parameterization (assume unit axis length) to do the rotation
@@ -172,11 +172,11 @@ function Base.convert(::Type{Q}, rv::RodriguesVec) where Q <: Quat
 end
 
 function Base.convert(::Type{RV}, q::Quat) where RV <: RodriguesVec
-    s2 = q.x*q.x + q.y*q.y + q.z*q.z
+    s2 = q.x * q.x + q.y * q.y + q.z * q.z
     cos_t2 = sqrt(s2)
-    theta = 2 * atan(cos_t2, q.w)
-    sc = ifelse(cos_t2 > 0, promote(theta / cos_t2, 2)...) # N.B. the 2 "should" match the derivitive as cos_t2 -> 0
-    return RV(sc * q.x, sc * q.y, sc * q.z )
+    theta = 2 * atan(cos_t2 / abs(q.w))
+    sc = ifelse(cos_t2 > 0, promote(copysign(theta / cos_t2, q.w), 2)...) # N.B. the 2 "should" match the derivitive as cos_t2 -> 0
+    return RV(sc * q.x, sc * q.y, sc * q.z)
 end
 
 

--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -82,7 +82,7 @@ end
     s2 = q.x * q.x + q.y * q.y + q.z * q.z
     cos_t2 = sqrt(s2)
     theta = 2 * atan(cos_t2 / abs(q.w))
-    sc = ifelse(cos_t2 > 0, promote(copysign(1 / cos_t2, q.w), 2)...) # N.B. the 2 "should" match the derivitive as cos_t2 -> 0
+    sc = ifelse(cos_t2 > 0, promote(copysign(1 / cos_t2, q.w), 2)...) # N.B. the 2 "should" match the derivative as cos_t2 -> 0
     return AA(theta, sc * q.x, sc * q.y, sc * q.z)
 end
 
@@ -175,7 +175,7 @@ function Base.convert(::Type{RV}, q::Quat) where RV <: RodriguesVec
     s2 = q.x * q.x + q.y * q.y + q.z * q.z
     cos_t2 = sqrt(s2)
     theta = 2 * atan(cos_t2 / abs(q.w))
-    sc = ifelse(cos_t2 > 0, promote(copysign(theta / cos_t2, q.w), 2)...) # N.B. the 2 "should" match the derivitive as cos_t2 -> 0
+    sc = ifelse(cos_t2 > 0, promote(copysign(theta / cos_t2, q.w), 2)...) # N.B. the 2 "should" match the derivative as cos_t2 -> 0
     return RV(sc * q.x, sc * q.y, sc * q.z)
 end
 

--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -80,9 +80,10 @@ end
 
 @inline function Base.convert(::Type{AA}, q::Quat) where AA <: AngleAxis
     # TODO: consider how to deal with derivative near theta = 0
+    qs = sign(q.w)
     s = sqrt(q.x*q.x + q.y*q.y + q.z*q.z)
-    theta =  2 * atan(s, q.w)
-    return s > 0 ? AA(theta, q.x / s, q.y / s, q.z / s, false) : AA(theta, one(theta), zero(theta), zero(theta), false)
+    theta =  2 * atan(s, qs * q.w)
+    return s > 0 ? AA(theta, qs * q.x / s, qs * q.y / s, qs * q.z / s, false) : AA(theta, one(theta), zero(theta), zero(theta), false)
 end
 
 # Using Rodrigues formula on an AngleAxis parameterization (assume unit axis length) to do the rotation

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -105,23 +105,20 @@ function jacobian(::Type{Quat},  X::SPQuat)
     alpha2 = X.x * X.x + X.y * X.y + X.z * X.z
     dA2dX = 2 * vspq
 
-    # the function we're differentiating forces q.w +ve
-    qs = sign((1-alpha2) / (alpha2 + 1))
-
     # f = (1-alpha2) / (alpha2 + 1);
     den2 = (alpha2 + 1) * (alpha2 + 1)
-    dQ1dX = qs * (-dA2dX * (alpha2 + 1) - dA2dX * (1-alpha2)) / den2
+    dQ1dX = (-dA2dX * (alpha2 + 1) - dA2dX * (1-alpha2)) / den2
 
     # do the on diagonal terms
     # f = 2*x / (alpha2 + 1) => g = 2*x, h = alpha2 + 1
     # df / dx = (dg * h - dh * g) / (h^2)
-    dQiDi = qs * 2 * ((alpha2 + 1) - dA2dX .* vspq) / den2
+    dQiDi = 2 * ((alpha2 + 1) - dA2dX .* vspq) / den2
 
     # do the off entries
     # f = 2x / (alpha2 + 1)
-    dQxDi = qs * -2 * vspq[1] * dA2dX / den2
-    dQyDi = qs * -2 * vspq[2] * dA2dX / den2
-    dQzDi = qs * -2 * vspq[3] * dA2dX / den2
+    dQxDi = -2 * vspq[1] * dA2dX / den2
+    dQyDi = -2 * vspq[2] * dA2dX / den2
+    dQzDi = -2 * vspq[3] * dA2dX / den2
 
     # assemble it all
     dQdX = @SMatrix [ dQ1dX[1]  dQ1dX[2]  dQ1dX[3] ;

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -134,18 +134,14 @@ end
 #
 # Jacobian converting from a Quaternion to an SpQuat
 #
-function jacobian(::Type{SPQuat},  q::Quat{T}) where T
-    den = (1 + q.w)
-    dalpha2dQs = (-den - (1 - q.w)) / (den * den)
-
-    dSpqdQs = 1/2 * SVector(q.x, q.y, q.z) * dalpha2dQs
-
-    alpha2 = (1 - q.w) / (1 + q.w)
-    dSpqdQv = 1/2 * (alpha2 + 1)
-
-    J0 = @SMatrix [ dSpqdQs[1]  dSpqdQv  zero(T)   zero(T) ;
-                    dSpqdQs[2]  zero(T)  dSpqdQv   zero(T) ;
-                    dSpqdQs[3]  zero(T)  zero(T)   dSpqdQv ]
+function jacobian(::Type{SPQuat}, q::Quat{T}) where T
+    den = 1 + q.w
+    scale = 1 / den
+    dscaledQw = -(scale * scale)
+    dSpqdQw = SVector(q.x, q.y, q.z) * dscaledQw
+    J0 = @SMatrix [ dSpqdQw[1]  scale   zero(T) zero(T) ;
+                    dSpqdQw[2]  zero(T) scale   zero(T) ;
+                    dSpqdQw[3]  zero(T) zero(T) scale ]
 
     # Need to project out norm component of Quat
     dQ = @SVector [q.w, q.x, q.y, q.z]

--- a/src/quaternion_types.jl
+++ b/src/quaternion_types.jl
@@ -220,7 +220,7 @@ end
 
 An `SPQuat` is a 3D rotation matrix represented by the "stereographic projection" of a normalized quaternion (shortened to "SPQuat"), which is
 a 3-element parametrization of a unit quaternion Q formed by the intersection of a line from [-1,0,0,0] to Q, with a plane containing the origin and with normal direction [1,0,0,0]. This
-is a compact representation of rotations where the derivitives of the rotation matrix's elements w.r.t. the SPQuat parameters are rational functions (making them useful for optimization).
+is a compact representation of rotations where the derivatives of the rotation matrix's elements w.r.t. the SPQuat parameters are rational functions (making them useful for optimization).
 
 See:
 

--- a/src/quaternion_types.jl
+++ b/src/quaternion_types.jl
@@ -23,7 +23,7 @@ struct Quat{T} <: Rotation{3,T}
 
     @inline function Quat{T}(w, x, y, z, normalize::Bool = true) where {T}
         if normalize
-            norm = copysign(sqrt(w*w + x*x + y*y + z*z), w)
+            norm = sqrt(w*w + x*x + y*y + z*z)
             new(w/norm, x/norm, y/norm, z/norm)
         else
             new(w, x, y, z)

--- a/src/quaternion_types.jl
+++ b/src/quaternion_types.jl
@@ -256,6 +256,10 @@ end
 @inline Base.getindex(spq::SPQuat, i::Int) = convert(Quat, spq)[i]
 @inline Base.Tuple(spq::SPQuat) = Tuple(convert(Quat, spq))
 
+# Optimizations for going between Quat and SPQuat
+@inline (::Type{SPQ})(q::Quat) where {SPQ <: SPQuat} = convert(SPQ, q)
+@inline (::Type{Q})(spq::SPQuat) where {Q <: Quat} = convert(Q, spq)
+
 @inline function Base.convert(::Type{Q}, spq::SPQuat) where Q <: Quat
     # Equation (45) in
     # Terzakis et al., "A Recipe on the Parameterization of Rotation Matrices

--- a/src/quaternion_types.jl
+++ b/src/quaternion_types.jl
@@ -262,8 +262,13 @@ end
 end
 
 @inline function Base.convert(::Type{SPQ}, q::Quat) where SPQ <: SPQuat
-    alpha2 = (1 - q.w) / (1 + q.w) # <= 1 since q.w >= 0
-    spq = SPQ(q.x * (alpha2 + 1)*0.5,  q.y * (alpha2 + 1)*0.5, q.z * (alpha2 + 1)*0.5)
+    # term = (alpha2 + 1) / 2
+    # term = ((1 - q.w) / (1 + q.w) + 1) / 2
+    # term = ((1 - q.w + (1 + q.w)) / (1 + q.w) / 2
+    # term = (2 / (1 + q.w)) / 2
+    # term = 1 / (1 + q.w)
+    term = 1 / (copysign(1, q.w) + q.w)  # incase q.w is not >= 0
+    spq = SPQ(q.x * term,  q.y * term, q.z * term)
 end
 
 @inline Base.:*(spq::SPQuat, x::StaticVector) = Quat(spq) * x

--- a/test/derivative_tests.jl
+++ b/test/derivative_tests.jl
@@ -28,8 +28,7 @@ using ForwardDiff
         # SPQuat to Quat
         @testset "Jacobian (SPQuat -> Quat)" begin
             for i = 1:10    # do some repeats
-                spq = rand(SPQuat)  # a random SPQUat
-                # TODO: should test the full domain of SPQuats, not just the one with ||.|| < 1
+                spq = rand(SPQuat)  # a random SPQuat
 
                 # test jacobian to a Rotation matrix
                 R_jac = Rotations.jacobian(Quat, spq)

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -142,6 +142,24 @@ all_types = (RotMatrix{3}, Quat, SPQuat, AngleAxis, RodriguesVec,
         end
     end
 
+    @testset "Quaternion double cover" begin
+        repeats = 100
+        for i = 1 : repeats
+            q = rand(Quat)
+
+            q2 = Quat(-q.w, -q.x, -q.y, -q.z) # normalize: need a tolerance
+            @test SVector(q2.w, q2.x, q2.y, q2.z) ≈ SVector(-q.w, -q.x, -q.y, -q.z) atol = 100 * eps()
+            @test q ≈ q2 atol = 100 * eps()
+
+            q3 = Quat(-q.w, -q.x, -q.y, -q.z, false) # don't normalize: everything is exact
+            @test (q3.w, q3.x, q3.y, q3.z) == (-q.w, -q.x, -q.y, -q.z)
+            @test q == q3
+
+            Δq = q \ q3
+            @test Δq ≈ one(Quat) atol = 100 * eps()
+        end
+    end
+
     # compose two random rotations
     @testset "Compose rotations" begin
         repeats = 100


### PR DESCRIPTION
Resolves #44. This came up again in https://github.com/JuliaRobotics/RigidBodyDynamics.jl/pull/484.

Combination of old commits from @rdeits and @ryanelandt (note his simplification for the `Quat` -> `SPQuat` case), plus some more tweaks I added.

Note that this also shortcuts `SPQuat(quat)` and `Quat(spquat)` so that these constructors directly call the appropriate `convert` methods, instead of converting e.g. `quat` to a `Tuple` (basically, rotation matrix), then converting it back to a `Quat` and only then `convert`ing to `SPQuat`. This made these conversions a bit faster and also improved my level of sanity.

This also makes it possible for randomly generated `SPQuat`s to have norm greater than one, since random `SPQuat`s are created by constructing an `SPQuat` from a random `Quat`, and the conversion from `Quat` to `SPQuat` now simply divides the vector component of the `Quat` by (1 + scalar component): negative scalar components result in a division by a number between 0 and 1. I personally think that's fine, but it's a point of discussion given https://github.com/FugroRoames/Rotations.jl/issues/44#issuecomment-328711148.

