### PR TITLE
Fixed bug in dQuat/dSpq jacobian. Added tests relevant to this issue.

### DIFF
--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -105,30 +105,26 @@ function jacobian(::Type{Quat},  X::SPQuat)
     alpha2 = X.x * X.x + X.y * X.y + X.z * X.z
     dA2dX = 2 * vspq
 
-    # the function we're differentiating forces q.w +ve
-    qs = sign((1-alpha2) / (alpha2 + 1))
-
     # f = (1-alpha2) / (alpha2 + 1);
     den2 = (alpha2 + 1) * (alpha2 + 1)
-    dQ1dX = qs * (-dA2dX * (alpha2 + 1) - dA2dX * (1-alpha2)) / den2
+    dQ1dX = (-dA2dX * (alpha2 + 1) - dA2dX * (1-alpha2)) / den2
 
     # do the on diagonal terms
     # f = 2*x / (alpha2 + 1) => g = 2*x, h = alpha2 + 1
     # df / dx = (dg * h - dh * g) / (h^2)
-    dQiDi = qs * 2 * ((alpha2 + 1) - dA2dX .* vspq) / den2
+    dQiDi = 2 * ((alpha2 + 1) - dA2dX .* vspq) / den2
 
     # do the off entries
     # f = 2x / (alpha2 + 1)
-    dQxDi = qs * -2 * vspq[1] * dA2dX / den2
-    dQyDi = qs * -2 * vspq[2] * dA2dX / den2
-    dQzDi = qs * -2 * vspq[3] * dA2dX / den2
+    dQxDi = -2 * vspq[1] * dA2dX / den2
+    dQyDi = -2 * vspq[2] * dA2dX / den2
+    dQzDi = -2 * vspq[3] * dA2dX / den2
 
     # assemble it all
     dQdX = @SMatrix [ dQ1dX[1]  dQ1dX[2]  dQ1dX[3] ;
                       dQiDi[1]  dQxDi[2]  dQxDi[3] ;
                       dQyDi[1]  dQiDi[2]  dQyDi[3] ;
                       dQzDi[1]  dQzDi[2]  dQiDi[3] ]
-
 
     return dQdX
 end

--- a/test/derivative_tests.jl
+++ b/test/derivative_tests.jl
@@ -28,12 +28,25 @@ using ForwardDiff
         # SPQuat to Quat
         @testset "Jacobian (SPQuat -> Quat)" begin
             for i = 1:10    # do some repeats
-                spq = rand(SPQuat)  # a random SPQUat
+                spq = rand(SPQuat)  # a random SPQuat
                 # TODO: should test the full domain of SPQuats, not just the one with ||.|| < 1
 
                 # test jacobian to a Rotation matrix
                 R_jac = Rotations.jacobian(Quat, spq)
-                FD_jac = ForwardDiff.jacobian(x -> (q = Quat(SPQuat(x[1],x[2],x[3]));
+                FD_jac = ForwardDiff.jacobian(x -> (q = convert(Quat, SPQuat(x[1],x[2],x[3]));
+                                                    SVector(q.w, q.x, q.y, q.z)),
+                                              SVector(spq.x, spq.y, spq.z))
+
+                # compare
+                @test FD_jac ≈ R_jac
+            end
+        end
+
+        @testset "Jacobian (SPQuat -> Quat) [Corner Cases]" begin
+            for spq = [SPQuat(1.0, 0.0, 0.0), SPQuat(0.0, 1.0, 0.0), SPQuat(0.0, 0.0, 1.0)]
+                # test jacobian to a Rotation matrix
+                R_jac = Rotations.jacobian(Quat, spq)
+                FD_jac = ForwardDiff.jacobian(x -> (q = convert(Quat, SPQuat(x[1],x[2],x[3]));
                                                     SVector(q.w, q.x, q.y, q.z)),
                                               SVector(spq.x, spq.y, spq.z))
 
@@ -49,7 +62,7 @@ using ForwardDiff
 
                 # test jacobian to a Rotation matrix
                 R_jac = Rotations.jacobian(SPQuat, q)
-                FD_jac = ForwardDiff.jacobian(x -> (spq = SPQuat(Quat(x[1],x[2],x[3],x[4]));
+                FD_jac = ForwardDiff.jacobian(x -> (spq = convert(SPQuat, Quat(x[1], x[2], x[3], x[4]));
                                                     SVector(spq.x, spq.y, spq.z)),
                                               SVector(q.w, q.x, q.y, q.z))
 
@@ -61,7 +74,7 @@ using ForwardDiff
         # SPQuat to rotation matrix
         @testset "Jacobian (SPQuat -> RotMatrix)" begin
             for i = 1:10    # do some repeats
-                spq = rand(SPQuat)  # a random quaternion
+                spq = rand(SPQuat)  # a random SPQuat
 
                 # test jacobian to a Rotation matrix
                 R_jac = Rotations.jacobian(RotMatrix, spq)


### PR DESCRIPTION
The jacobian dQuat_dSPQ is a matrix of zeros for things like `Rotations.jacobian(Quat, SPQuat(1.0, 0.0, 0.0))`.

Note: `SPQuat(1.0, 0.0, 0.0)` is the projection of `Quat(0.0, 1.0, 0.0, 0.0)` which has a non-negative real part.