### PR TITLE
Fix quat to aa

### DIFF
--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -82,9 +82,9 @@ end
     s2 = q.x * q.x + q.y * q.y + q.z * q.z
     sin_t2 = sqrt(s2)
     theta = 2 * atan(sin_t2, q.w)
-    eps_theta = eps(typeof(theta))
-    inv_sin_t2 = 1 / (sin_t2 + eps_theta)
-    return principal_value(AA(theta, inv_sin_t2 * (q.x + eps_theta), inv_sin_t2 * q.y, inv_sin_t2 * q.z))
+    num_pert = eps(typeof(theta))^2
+    inv_sin_t2 = 1 / (sin_t2 + num_pert)
+    return principal_value(AA(theta, inv_sin_t2 * (q.x + num_pert), inv_sin_t2 * q.y, inv_sin_t2 * q.z))
 end
 
 # Using Rodrigues formula on an AngleAxis parameterization (assume unit axis length) to do the rotation

--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -80,10 +80,11 @@ end
 
 @inline function Base.convert(::Type{AA}, q::Quat) where AA <: AngleAxis
     s2 = q.x * q.x + q.y * q.y + q.z * q.z
-    cos_t2 = sqrt(s2)
-    theta = 2 * atan(cos_t2 / abs(q.w))
-    sc = ifelse(cos_t2 > 0, promote(copysign(1 / cos_t2, q.w), 2)...) # N.B. the 2 "should" match the derivative as cos_t2 -> 0
-    return AA(theta, sc * q.x, sc * q.y, sc * q.z)
+    sin_t2 = sqrt(s2)
+    theta = 2 * atan(sin_t2, q.w)
+    eps_theta = eps(typeof(theta))
+    inv_sin_t2 = 1 / (sin_t2 + eps_theta)
+    return principal_value(AA(theta, inv_sin_t2 * (q.x + eps_theta), inv_sin_t2 * q.y, inv_sin_t2 * q.z))
 end
 
 # Using Rodrigues formula on an AngleAxis parameterization (assume unit axis length) to do the rotation

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -234,6 +234,7 @@ all_types = (RotMatrix{3}, Quat, SPQuat, AngleAxis, RodriguesVec,
                 @test rotation_axis(r2) ≈ axis
             end
         end
+	@test norm(rotation_axis(Quat(1.0, 0.0, 0.0, 0.0))) ≈ 1.0
 
         # TODO RotX, RotXY?
     end


### PR DESCRIPTION
**Background:** The issue with AngleAxis about theta=0 is that it is not differentiable. One can handle this one of two ways: 1.) handle theta=0 as a separate case or 2.) numerically perturb the solution. This PR takes the latter approach.

**Problem:** As currently written, `AngleAxis(Quat(1.0, 0.0, 0.0, 0.0))` produces `AngleAxis(0.0, NaN, NaN, NaN)` which (although sort of correct) is generally not what people want (it also breaks unit tests in RigidBodyDynamics which is how I found it).

The numerical perturbation biases the rotation axis toward `[1.0, 0.0, 0.0]`. Below are ceratin cases where this effect is noticeable:
`AngleAxis(Quat(1.0, 0.0, 1.0e-17, 0.0))` produces AngleAxis(0.0, 4.93038e-15, 1.0, 0.0)
`AngleAxis(Quat(1.0, 0.0, 0.0, 0.0))` produces AngleAxis(0.0, 1.0, 0.0, 0.0)