### PR TITLE
Minor performance improvements.

### DIFF
--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -84,7 +84,7 @@ end
     theta = 2 * atan(sin_t2, q.w)
     num_pert = eps(typeof(theta))^2
     inv_sin_t2 = 1 / (sin_t2 + num_pert)
-    return principal_value(AA(theta, inv_sin_t2 * (q.x + num_pert), inv_sin_t2 * q.y, inv_sin_t2 * q.z))
+    return principal_value(AA(theta, inv_sin_t2 * (q.x + num_pert), inv_sin_t2 * q.y, inv_sin_t2 * q.z, false))
 end
 
 # Using Rodrigues formula on an AngleAxis parameterization (assume unit axis length) to do the rotation
@@ -172,14 +172,7 @@ function Base.convert(::Type{Q}, rv::RodriguesVec) where Q <: Quat
     return Q(qtheta, s * rv.sx, s * rv.sy, s * rv.sz, false)
 end
 
-function Base.convert(::Type{RV}, q::Quat) where RV <: RodriguesVec
-    s2 = q.x * q.x + q.y * q.y + q.z * q.z
-    cos_t2 = sqrt(s2)
-    theta = 2 * atan(cos_t2 / abs(q.w))
-    sc = ifelse(cos_t2 > 0, promote(copysign(theta / cos_t2, q.w), 2)...) # N.B. the 2 "should" match the derivative as cos_t2 -> 0
-    return RV(sc * q.x, sc * q.y, sc * q.z)
-end
-
+Base.convert(::Type{RV}, q::Quat) where {RV <: RodriguesVec} = convert(RV, convert(AngleAxis, q))
 
 function Base.:*(rv::RodriguesVec{T1}, v::StaticVector{3, T2}) where {T1,T2}
     theta = rotation_angle(rv)

--- a/src/principal_value.jl
+++ b/src/principal_value.jl
@@ -6,13 +6,13 @@ mod_minus_pi_to_pi(a::T) where {T} = mod2pi(a + pi) - pi
 **Background:** All non `RotMatrix` rotation types can represent the same `RotMatrix` in two or more ways. Sometimes a
 particular set of numbers is better conditioned (e.g. `SPQuat`) or obeys a particular convention (e.g. `AngleAxis` has
 non-negative rotation). In order to preserve differentiability it is necessary to allow rotation representations to
-travel slightly away from the nominal domain; this is critical for applications such as optimization or dynamics. 
+travel slightly away from the nominal domain; this is critical for applications such as optimization or dynamics.
 
 This function takes a rotation type (e.g. `Quat`, `RotXY`) and outputs a new rotation of the same type that corresponds
 to the same `RotMatrix`, but that obeys certain conventions or is better conditioned. The outputs of the function have
 the following properties:
 
-- all angles are between between `-pi` to `pi` (except for `AngleAxis` which is between `0` and `pi`). 
+- all angles are between between `-pi` to `pi` (except for `AngleAxis` which is between `0` and `pi`).
 - all `Quat` have non-negative real part
 - the components of all `SPQuat` have a norm that is at most 1.
 - the `RodriguesVec` rotation is at most `pi`
@@ -25,9 +25,9 @@ principal_value(spq::SPQuat{T}) where {T} = convert(SPQuat, principal_value(conv
 function principal_value(aa::AngleAxis{T}) where {T}
     theta = mod_minus_pi_to_pi(aa.theta)
     if theta < zero(T)
-        return AngleAxis(-theta, -aa.axis_x, -aa.axis_y, -aa.axis_z)
+        return AngleAxis(-theta, -aa.axis_x, -aa.axis_y, -aa.axis_z, false)
     else
-        return AngleAxis( theta,  aa.axis_x,  aa.axis_y,  aa.axis_z)
+        return AngleAxis( theta,  aa.axis_x,  aa.axis_y,  aa.axis_z, false)
     end
 end
 


### PR DESCRIPTION
Skip a few unnecessary normalizations.

Would be nice to eventually change that optional argument to a keyword argument now that those are fast.

Also change `Quat` -> `RodriguesVec` according to https://github.com/FugroRoames/Rotations.jl/pull/77#issuecomment-420276890.