### PR TITLE
Add check for improper rotations #80 to isrotation

### DIFF
--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -149,7 +149,7 @@ function isrotation(r::AbstractMatrix{T}, tol::Real = 1000 * eps(eltype(T))) whe
         return false
     end
 
-    return d < tol
+    return d < tol&&det(r)>0
 end
 
 # A simplification and specialization of the Base.show function for AbstractArray makes

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -308,12 +308,13 @@ all_types = (RotMatrix{3}, Quat, SPQuat, AngleAxis, RodriguesVec,
       foreach(rot_types) do rot_type
         foreach(1:20) do idx
           @test isrotation(rand(rot_type))
-
         end 
-
       end
-
       a=[40.0 0.0 0.0
+         0.0 0.0 1.0
+         0.0 1.0 0.0]
+      @test !isrotation(a) 
+      a=[1.0 0.0 0.0
          0.0 0.0 1.0
          0.0 1.0 0.0]
       @test !isrotation(a) 


### PR DESCRIPTION
I don't think anybody was using isrotation as it was totally broken until yesterday.

This change assures that matrix rotations can be converted to other kinds of rotations.