### PR TITLE
Skip normalization in `one`.

### DIFF
--- a/src/quaternion_types.jl
+++ b/src/quaternion_types.jl
@@ -188,8 +188,8 @@ function Base.inv(q::Quat)
     Quat(q.w, -q.x, -q.y, -q.z)
 end
 
-@inline Base.one(::Type{Quat}) = Quat(1.0, 0.0, 0.0, 0.0)
-@inline Base.one(::Type{Quat{T}}) where {T} = Quat{T}(one(T), zero(T), zero(T), zero(T))
+@inline Base.one(::Type{Quat}) = Quat(1.0, 0.0, 0.0, 0.0, false)
+@inline Base.one(::Type{Quat{T}}) where {T} = Quat{T}(one(T), zero(T), zero(T), zero(T), false)
 
 """
     rotation_between(from, to)


### PR DESCRIPTION
No need for it, and was preventing usage with `T`s for which `sqrt` isn't defined.