### PR TITLE
Clarify the interpretation of composed Euler angle rotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ j2 = Rotations.jacobian(q, p) # How does the rotated point q*p change w.r.t. the
 
     A composition of 3 cardinal axis rotations is typically known as a Euler
     angle parameterization of a 3D rotation. The rotations with 3 unique axes,
-    such as `RotXYZ`, are said to follow the [**Tait Byran**](https://en.wikipedia.org/wiki/Euler_angles#Tait.E2.80.93Bryan_angles) angle ordering,
+    such as `RotXYZ`, are said to follow the [**Tait Bryan**](https://en.wikipedia.org/wiki/Euler_angles#Tait.E2.80.93Bryan_angles) angle ordering,
     while those which repeat (e.g. `EulerXYX`) are said to use [**Proper Euler**](https://en.wikipedia.org/wiki/Euler_angles#Conventions) angle ordering.
 
     Like the two-angle versions, read the application of the rotations along the

--- a/README.md
+++ b/README.md
@@ -134,11 +134,7 @@ j2 = Rotations.jacobian(q, p) # How does the rotated point q*p change w.r.t. the
     such as `RotXYZ`, are said to follow the [**Tait Bryan**](https://en.wikipedia.org/wiki/Euler_angles#Tait.E2.80.93Bryan_angles) angle ordering,
     while those which repeat (e.g. `EulerXYX`) are said to use [**Proper Euler**](https://en.wikipedia.org/wiki/Euler_angles#Conventions) angle ordering.
 
-    Like the two-angle versions, read the application of the rotations along the
-    static cardinal axes to a vector from right-to-left, so that `RotXYZ(x, y, z) * v == RotX(x) * (RotY(y) * (RotZ(z) * v))`.
-    This is the "extrinsic" representation of an Euler-angle rotation, though
-    if you prefer the "intrinsic" form it is easy to use the corresponding
-    `RotZYX(z, y, x)`.
+    Like the two-angle versions, the order of application to a vector is right-to-left, so that `RotXYZ(x, y, z) * v == RotX(x) * (RotY(y) * (RotZ(z) * v))`.  This may be interpreted as an "extrinsic" rotation about the Z, Y, and X axes or as an "intrinsic" rotation about the X, Y, and Z axes.  Similarly, `RotZYX(z, y, x)` may be interpreted as an "extrinsic" rotation about the X, Y, and Z axes or an "intrinsic" rotation about the Z, Y, and X axes. 
 
 ### Import / Export
 


### PR DESCRIPTION
I've been comparing your conventions for composition of Euler angle rotations to my own.  I found the current description of the rotations as extrinsic somewhat confusing.

The key seems to be that your naming convention reflects the order of the matrix products, not the order of rotation.  The same matrix product may be interpreted as either intrinsic or extrinsic, depending on the order of rotation used.

Does my change make sense to others, or am I just making things more confusing?