### PR TITLE
Fix deprecation warning with newer StaticArrays versions.

### DIFF
--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -112,7 +112,7 @@ function jacobian(::Type{Quat},  X::SPQuat)
     # do the on diagonal terms
     # f = 2*x / (alpha2 + 1) => g = 2*x, h = alpha2 + 1
     # df / dx = (dg * h - dh * g) / (h^2)
-    dQiDi = 2 * ((alpha2 + 1) - dA2dX .* vspq) / den2
+    dQiDi = 2 * ((alpha2 + 1) .- dA2dX .* vspq) / den2
 
     # do the off entries
     # f = 2x / (alpha2 + 1)


### PR DESCRIPTION
Should be backwards compatible; broadcasting was implemented a long time
ago.