### PR TITLE
Make rotations in degrees exact

### DIFF
--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -1,7 +1,7 @@
 ################################################################################
 ################################################################################
 """
-    struct AngleAxis{T} <: Rotation{3,T}
+    struct AngleAxis{T,A} <: Rotation{3,T}
     AngleAxis(Θ, x, y, z)
 
 A 3×3 rotation matrix parameterized by a 3D rotation by angle θ about an
@@ -20,19 +20,19 @@ represent a normalized rotation axis. Operations on an `AngleAxis` with a rotati
 axis that does not have unit norm, created by skipping renormalization in this fashion,
 are not guaranteed to do anything sensible.
 """
-struct AngleAxis{T} <: Rotation{3,T}
-    theta::T
+struct AngleAxis{T,A} <: Rotation{3,T}
+    theta::A
     axis_x::T
     axis_y::T
     axis_z::T
 
-    @inline function AngleAxis{T}(θ, x, y, z, normalize::Bool = true) where {T}
+    @inline function AngleAxis{T}(θ::A, x, y, z, normalize::Bool = true) where {T,A}
         if normalize
             # Not sure what to do with theta?? Should it become theta * norm ?
             norm = sqrt(x*x + y*y + z*z)
-            new(θ, x/norm, y/norm, z/norm)
+            new{T,A}(θ, x/norm, y/norm, z/norm)
         else
-            new(θ, x, y, z)
+            new{T,A}(θ, x, y, z)
         end
     end
 end
@@ -42,7 +42,7 @@ params(aa::AngleAxis) = SVector{4}(aa.theta, aa.axis_x, aa.axis_y, aa.axis_z)
 # StaticArrays will take over *all* the constructors and put everything in a tuple...
 # but this isn't quite what we mean when we have 4 inputs (not 9).
 @inline function AngleAxis(θ::Θ, x::X, y::Y, z::Z, normalize::Bool = true) where {Θ,X,Y,Z}
-    AngleAxis{promote_type(promote_type(promote_type(Θ, X), Y), Z)}(θ, x, y, z, normalize)
+    AngleAxis{reduce(promote_type, (rot_eltype(Θ),X,Y,Z,))}(θ, x, y, z, normalize)
 end
 
 # These functions are enough to satisfy the entire StaticArrays interface:

--- a/src/angleaxis_types.jl
+++ b/src/angleaxis_types.jl
@@ -1,7 +1,7 @@
 ################################################################################
 ################################################################################
 """
-    struct AngleAxis{T,A} <: Rotation{3,T}
+    struct AngleAxis{T} <: Rotation{3,T}
     AngleAxis(Θ, x, y, z)
 
 A 3×3 rotation matrix parameterized by a 3D rotation by angle θ about an
@@ -20,19 +20,19 @@ represent a normalized rotation axis. Operations on an `AngleAxis` with a rotati
 axis that does not have unit norm, created by skipping renormalization in this fashion,
 are not guaranteed to do anything sensible.
 """
-struct AngleAxis{T,A} <: Rotation{3,T}
-    theta::A
+struct AngleAxis{T} <: Rotation{3,T}
+    theta::T
     axis_x::T
     axis_y::T
     axis_z::T
 
-    @inline function AngleAxis{T}(θ::A, x, y, z, normalize::Bool = true) where {T,A}
+    @inline function AngleAxis{T}(θ, x, y, z, normalize::Bool = true) where {T}
         if normalize
             # Not sure what to do with theta?? Should it become theta * norm ?
             norm = sqrt(x*x + y*y + z*z)
-            new{T,A}(θ, x/norm, y/norm, z/norm)
+            new(θ, x/norm, y/norm, z/norm)
         else
-            new{T,A}(θ, x, y, z)
+            new(θ, x, y, z)
         end
     end
 end
@@ -42,7 +42,7 @@ params(aa::AngleAxis) = SVector{4}(aa.theta, aa.axis_x, aa.axis_y, aa.axis_z)
 # StaticArrays will take over *all* the constructors and put everything in a tuple...
 # but this isn't quite what we mean when we have 4 inputs (not 9).
 @inline function AngleAxis(θ::Θ, x::X, y::Y, z::Z, normalize::Bool = true) where {Θ,X,Y,Z}
-    AngleAxis{reduce(promote_type, (rot_eltype(Θ),X,Y,Z,))}(θ, x, y, z, normalize)
+    AngleAxis{promote_type(promote_type(promote_type(Θ, X), Y), Z)}(θ, x, y, z, normalize)
 end
 
 # These functions are enough to satisfy the entire StaticArrays interface:

--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -160,7 +160,7 @@ of `getindex` etc. are computed on the fly.
 """
 struct Angle2d{T,A} <: Rotation{2,T}
     theta::A
-		Angle2d{T,A}(theta::Number) where{T,A} = new{T,A}(theta)
+    Angle2d{T,A}(theta::Number) where{T,A} = new{T,A}(theta)
     Angle2d{T}(theta::A) where {T,A} = new{T,A}(theta)
 end
 

--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -150,17 +150,17 @@ Base.inv(r::RotMatrix) = RotMatrix(r.mat')
 end
 
 """
-    struct Angle2d{T} <: Rotation{2,T}
-        theta::T
+    struct Angle2d{T,A} <: Rotation{2,T}
+        theta::A
     end
 
 A 2×2 rotation matrix parameterized by a 2D rotation by angle.
 Only the angle is stored inside the `Angle2d` type, values
 of `getindex` etc. are computed on the fly.
 """
-struct Angle2d{T} <: Rotation{2,T}
-    theta::T
-    Angle2d{T}(theta) where T = new{T}(theta)
+struct Angle2d{T,A} <: Rotation{2,T}
+    theta::A
+    Angle2d{T}(theta::A) where {T,A} = new{T,A}(theta)
 end
 
 @inline function Angle2d(theta)

--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -160,6 +160,7 @@ of `getindex` etc. are computed on the fly.
 """
 struct Angle2d{T,A} <: Rotation{2,T}
     theta::A
+		Angle2d{T,A}(theta::Number) where{T,A} = new{T,A}(theta)
     Angle2d{T}(theta::A) where {T,A} = new{T,A}(theta)
 end
 
@@ -171,6 +172,7 @@ params(r::Angle2d) = SVector{1}(r.theta)
 
 Angle2d(r::Rotation{2}) = Angle2d(rotation_angle(r))
 Angle2d{T}(r::Rotation{2}) where {T} = Angle2d{T}(rotation_angle(r))
+Angle2d{T,A}(r::Rotation{2}) where{T,A} = Angle2d{T,A}(rotation_angle(r))
 
 Base.one(::Type{A}) where {A<: Angle2d} = A(0)
 

--- a/src/euler_types.jl
+++ b/src/euler_types.jl
@@ -12,10 +12,12 @@
 for axis in [:X, :Y, :Z]
     RotType = Symbol("Rot" * string(axis))
     @eval begin
-        struct $RotType{T} <: Rotation{3,T}
-            theta::T
-            $RotType{T}(theta) where {T} = new{T}(theta)
-            $RotType{T}(r::$RotType) where {T} = new{T}(r.theta)
+        struct $RotType{T,A} <: Rotation{3,T}
+            theta::A
+            $RotType{T,A}(theta) where{T,A} = new{T,A}(theta)
+            $RotType{T}(theta::A) where {T,A} = new{T,A}(theta)
+            $RotType{T,A}(r::$RotType) where{T,A} = new{T,A}(r.theta)
+            $RotType{T}(r::$RotType) where {T} = $RotType{T}(r.theta)
         end
 
         @inline function $RotType(theta)
@@ -220,11 +222,13 @@ for axis1 in [:X, :Y, :Z]
         InvRotType = Symbol("Rot" * string(axis2) * string(axis1))
 
         @eval begin
-            struct $RotType{T} <: Rotation{3,T}
-                theta1::T
-                theta2::T
-                $RotType{T}(theta1, theta2) where {T} = new{T}(theta1, theta2)
-                $RotType{T}(r::$RotType) where {T} = new{T}(r.theta1, r.theta2)
+            struct $RotType{T,A} <: Rotation{3,T}
+                theta1::A
+                theta2::A
+                $RotType{T,A}(theta1,theta2) where{T,A} = new{T,A}(theta1, theta2)
+                $RotType{T}(theta1::A, theta2::A) where {T,A} = new{T,A}(theta1, theta2)
+                $RotType{T,A}(r::$RotType) where{T,A} = new{T,A}(r.theta1, r.theta2)
+                $RotType{T}(r::$RotType) where {T} = $RotType{T}(r.theta1, r.theta2)
             end
 
             @inline function $RotType(theta1, theta2)
@@ -513,12 +517,14 @@ for axis1 in [:X, :Y, :Z]
             Rot0Type = Symbol("Rot" * string(axis0))
 
             @eval begin
-                struct $RotType{T} <: Rotation{3,T}
-                    theta1::T
-                    theta2::T
-                    theta3::T
-                    $RotType{T}(theta1, theta2, theta3) where {T} = new{T}(theta1, theta2, theta3)
-                    $RotType{T}(r::$RotType) where {T} = new{T}(r.theta1, r.theta2, r.theta3)
+                struct $RotType{T,A} <: Rotation{3,T}
+                    theta1::A
+                    theta2::A
+                    theta3::A
+                    $RotType{T,A}(theta1,theta2,theta3) where{T,A} = new{T,A}(theta1, theta2, theta3)
+                    $RotType{T}(theta1::A, theta2::A, theta3::A) where {T,A} = new{T,A}(theta1, theta2, theta3)
+                    $RotType{T,A}(r::$RotType) where{T,A} = new{T,A}(r.theta1, r.theta2, r.theta3)
+                    $RotType{T}(r::$RotType) where {T} = $RotType{T}(r.theta1, r.theta2, r.theta3)
                 end
 
                 @inline function $RotType(theta1, theta2, theta3)

--- a/test/2d.jl
+++ b/test/2d.jl
@@ -18,6 +18,9 @@ using Unitful
         # don't extraneously contain those units (see issue #55)
         @test eltype(Angle2d(10u"°")) <: Real
         @test eltype(Angle2d(20u"rad")) <: Real
+
+				# Check exactitude of degree rotations
+				@test Angle2d(360u"°") == [1 0;0 1]
     end
 
     ###############################

--- a/test/2d.jl
+++ b/test/2d.jl
@@ -19,8 +19,8 @@ using Unitful
         @test eltype(Angle2d(10u"°")) <: Real
         @test eltype(Angle2d(20u"rad")) <: Real
 
-				# Check exactitude of degree rotations
-				@test Angle2d(360u"°") == [1 0;0 1]
+        # Check exactitude of degree rotations
+        @test Angle2d(360u"°") == [1 0;0 1]
     end
 
     ###############################

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -470,7 +470,7 @@ all_types = (RotMatrix{3}, AngleAxis, RotationVec,
         rxyz = RotXYZ(1.0, 2.0, 3.0)
         show(io, MIME("text/plain"), rxyz)
         str = String(take!(io))
-        @test startswith(str, "3×3 RotXYZ{Float64}") && occursin("(1.0, 2.0, 3.0):", str)
+        @test startswith(str, "3×3 RotXYZ{Float64,") && occursin("(1.0, 2.0, 3.0):", str)
     end
 
     #########################################################################

--- a/test/rotation_tests.jl
+++ b/test/rotation_tests.jl
@@ -491,4 +491,16 @@ all_types = (RotMatrix{3}, AngleAxis, RotationVec,
         @test Rotations.params(MRP(p1,p2,p3)) == [p1,p2,p3]
         @test Rotations.params(RodriguesParam(p1,p2,p3)) == [p1,p2,p3]
     end
+
+		@testset "Exact rotations in degrees" begin
+			using Unitful: °
+			hascoeffs(m, l...) = all(l) do ((i,j),y) m[i,j] == y end
+			@test hascoeffs(RotX(30°), (1,1)=>1, (2,3)=>-1/2, (3,2)=>1/2)
+			@test hascoeffs(RotX(60°), (1,1)=>1, (2,2)=>1/2, (3,3)=>1/2)
+			@test hascoeffs(RotXY(90°,60°), (1,1)=>1/2,(2,3)=>-1/2,(3,2)=>1)
+			@test hascoeffs(RotXYZ(30°,60°,90°),
+				(1,2)=>-1/2,(2,3)=>-1/4,(3,1)=>1/2)
+			# FIXME: this should also have (3,2)=>3/4, but exactness here is as
+			# a *product* of trigonometric functions simplifying √3...
+		end
 end


### PR DESCRIPTION
This PR adds a second type parameter to angular rotations type (`Angle2d` and all `RotX` etc.). This prevents automatic conversion of the angle to floating-point and the resulting inexactitude when angles are in degrees.